### PR TITLE
Migrated to Gradle 5.0 and travis-ci changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,10 @@ services:
   - docker
 
 jdk:
+  - openjdk8
   - oraclejdk8
-
-python:
-  - "2.7"
+  - oraclejdk9
+  - oraclejdk11
 
 before_install:
   - docker pull opendxl/opendxl-broker
@@ -17,8 +17,7 @@ before_install:
   - docker ps -a
 
 before_script:
-  - pip install --user dxlclient
-  - python -m dxlclient provisionconfig clientconfig 127.0.0.1 client -u admin -p password
+  - java -jar ./build/libs/dxlclient*all.jar provisionconfig clientconfig 127.0.0.1 client -u admin -p password
   - sed -i -e "s/127.0.0.1;127.0.0.1/127.0.0.1/g" -e "/local/d" -e "/docker/d" clientconfig/dxlclient.config
   - cat clientconfig/dxlclient.config
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,3 @@
-import com.sun.xml.internal.bind.v2.schemagen.xmlschema.Documentation
 
 buildscript {
     repositories {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/com/opendxl/client/DisconnectedStrategy.java
+++ b/src/main/java/com/opendxl/client/DisconnectedStrategy.java
@@ -10,5 +10,5 @@ public interface DisconnectedStrategy {
      *
      * @param client The DXL client
      */
-    void onDisconnect(final DxlClient client);
+    void onDisconnect(DxlClient client);
 }

--- a/src/main/java/com/opendxl/client/cli/CommandLineInterface.java
+++ b/src/main/java/com/opendxl/client/cli/CommandLineInterface.java
@@ -24,14 +24,15 @@ import java.net.URISyntaxException;
  * <p>
  * There are three CLI commands for the OpenDXL Java Client:
  * </p>
- * <table summary="List of CLI commands for OpenDXL Java Client" border="0" cellpadding="8" cellspacing="0">
- * <tr align="left" style="background-color: #CCCCFF;">
- * <th align="left" id="commandName" style="white-space: nowrap;">Command Name</th>
- * <th align="left" id="commandInfo">Command Information</th>
+ * <table style="border-spacing: 0px;">
+ * <caption>List of CLI commands for OpenDXL Java Client</caption>
+ * <tr style="background-color: #CCCCFF;">
+ * <th id="commandName" style="text-align: left; white-space: nowrap; padding: 8px;">Command Name</th>
+ * <th id="commandInfo" style="text-align: left; padding: 8px;">Command Information</th>
  * </tr>
  * <tr>
- * <th style="vertical-align: top;">provisionconfig</th>
- * <td style="vertical-align: top;">
+ * <th style="vertical-align: top; padding: 8px;">provisionconfig</th>
+ * <td style="vertical-align: top; padding: 8px;">
  * This command is for provisioning a DXL Client and performs the following steps:
  * <ul>
  * <li>
@@ -125,8 +126,8 @@ import java.net.URISyntaxException;
  * </td>
  * </tr>
  * <tr>
- * <th style="vertical-align: top;">updateconfig</th>
- * <td style="vertical-align: top;">
+ * <th style="vertical-align: top; padding: 8px;">updateconfig</th>
+ * <td style="vertical-align: top; padding: 8px;">
  * This command is for updating the DXL client configuration in the dxlclient.config file, specifically the
  * ca bundle and broker configuration.
  * <p>
@@ -220,8 +221,8 @@ import java.net.URISyntaxException;
  * </td>
  * </tr>
  * <tr>
- * <th style="vertical-align: top;">generatecsr</th>
- * <td style="vertical-align: top;">
+ * <th style="vertical-align: top; padding: 8px;">generatecsr</th>
+ * <td style="vertical-align: top; padding: 8px;">
  * This command is for generating a private key and CSR
  * <p>
  * The provision DXL Client command requires three CLI arguments:

--- a/src/test/java/com/opendxl/client/cli/CommandLineInterfaceTest.java
+++ b/src/test/java/com/opendxl/client/cli/CommandLineInterfaceTest.java
@@ -1,14 +1,44 @@
 package com.opendxl.client.cli;
 
+import org.apache.commons.io.FileUtils;
+import org.bouncycastle.asn1.ASN1Encodable;
+import org.bouncycastle.asn1.ASN1ObjectIdentifier;
+import org.bouncycastle.asn1.ASN1Primitive;
+import org.bouncycastle.asn1.ASN1String;
+import org.bouncycastle.asn1.pkcs.Attribute;
+import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
+import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x500.X500NameBuilder;
+import org.bouncycastle.asn1.x500.style.BCStyle;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.Extensions;
+import org.bouncycastle.asn1.x509.GeneralName;
+import org.bouncycastle.asn1.x509.GeneralNames;
+import org.bouncycastle.openssl.PEMParser;
+import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
+import org.bouncycastle.pkcs.PKCS10CertificationRequest;
+import org.bouncycastle.util.io.pem.PemObject;
+import org.bouncycastle.util.io.pem.PemReader;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.ExpectedSystemExit;
 import org.junit.contrib.java.lang.system.SystemErrRule;
 import org.junit.contrib.java.lang.system.SystemOutRule;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStreamReader;
+import java.security.PrivateKey;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 
 /**
@@ -86,18 +116,101 @@ public class CommandLineInterfaceTest {
                     "  -t, --port=PORT            Port where the management service resides%n" +
                     "  -u, --user=USERNAME        User registered at the management service%n" +
                     "  -V, --version              Print version information and exit.%n");
-    private static final String GENERATE_CSR_USAGE = "";
-    private static final String UPDATE_CONFIG_USAGE = "";
 
+    /**
+     * Usage help string for the generatecsr CLI command
+     */
+    private static final String GENERATE_CSR_USAGE =
+            String.format(Locale.ROOT, "Usage: java -jar dxlclient-all.jar generatecsr [-hV] [--verbose]%n" +
+                    "                                               [--country=COUNTRY]%n" +
+                    "                                               [--email-address=EMAIL]%n" +
+                    "                                               [--locality=LOCALITY]%n" +
+                    "                                               [--organization=ORG]%n" +
+                    "                                               [--organizational-unit=ORG_UNIT]%n" +
+                    "                                               [--state-or-province=STATE]%n" +
+                    "                                               [-f=PREFIX] [-P=PASS] [-s%n" +
+                    "                                               [=NAME...]]... CONFIGDIR%n" +
+                    "                                               COMMON_NAME%n" +
+                    "Generate CSR and private key%n" +
+                    "%n" +
+                    "positional arguments:%n" +
+                    "      CONFIGDIR              Path to the config directory%n" +
+                    "      COMMON_NAME            Common Name (CN) to use in the CSR's Subject DN%n" +
+                    "%n" +
+                    "optional arguments:%n" +
+                    "      --country=COUNTRY      Country (C) to use in the CSR's Subject DN%n" +
+                    "      --email-address=EMAIL  e-mail address to use in the CSR's Subject DN%n" +
+                    "      --locality=LOCALITY    Locality (L) to use in the CSR's Subject DN%n" +
+                    "      --organization=ORG     Organization (O) to use in the CSR's Subject DN%n" +
+                    "      --organizational-unit=ORG_UNIT%n" +
+                    "                             Organizational Unit (OU) to use in the CSR's Subject DN%n" +
+                    "      --state-or-province=STATE%n" +
+                    "                             State or province (ST) to use in the CSR's Subject DN%n" +
+                    "      --verbose              Verbose mode. Increases the log level to DEBUG%n" +
+                    "  -f, --file-prefix=PREFIX   file prefix to use for CSR, key, and cert files.%n" +
+                    "                               (default: client)%n" +
+                    "  -h, --help                 Show this help message and exit.%n" +
+                    "  -P, --passphrase=PASS      private key passphrase%n" +
+                    "  -s, --san[=NAME...]        add Subject Alternative Name(s) to the CSR%n" +
+                    "  -V, --version              Print version information and exit.%n");
+
+    /**
+     * Usage help string for the updateconfig CLI command
+     */
+    private static final String UPDATE_CONFIG_USAGE = String.format(Locale.ROOT,
+            "Usage: java -jar dxlclient-all.jar updateconfig [-hV] [--verbose]%n" +
+                    "                                                [-e=TRUSTSTORE_FILE]%n" +
+                    "                                                [-p=PASSWORD] [-t=PORT]%n" +
+                    "                                                [-u=USERNAME] CONFIGDIR HOSTNAME%n" +
+                    "Update the DXL client configuration%n" +
+                    "%n" +
+                    "positional arguments:%n" +
+                    "      CONFIGDIR             Path to the config directory%n" +
+                    "      HOSTNAME              Hostname where the management service resides%n" +
+                    "%n" +
+                    "optional arguments:%n" +
+                    "      --verbose             Verbose mode. Increases the log level to DEBUG%n" +
+                    "  -e, --truststore=TRUSTSTORE_FILE%n" +
+                    "                            Name of file containing one or more CA pems to use in%n" +
+                    "                              validating the management server%n" +
+                    "  -h, --help                Show this help message and exit.%n" +
+                    "  -p, --password=PASSWORD   Password for the management service user%n" +
+                    "  -t, --port=PORT           Port where the management service resides%n" +
+                    "  -u, --user=USERNAME       User registered at the management service%n" +
+                    "  -V, --version             Print version information and exit.%n");
+
+    /**
+     * Provision DXL Client CLI command
+     */
     private static final String PROVISION_COMMAND = "provisionconfig";
+    /**
+     * Generate a CSR CLI command
+     */
     private static final String GENERATE_CSR_COMMAND = "generatecsr";
+    /**
+     * Update the DXL Config CLI command
+     */
     private static final String UPDATE_CONFIG_COMMAND = "updateconfig";
 
+    private static final String TEMP_FILE_DIR_NAME = "tempFileDir";
 
+    private static final String CSR_COMMON_NAME = "client1";
+
+    private static final String DEFAULT_FILE_PREFIX = "client";
+
+    /**
+     * The System Out rule
+     */
     @Rule
-    public final SystemOutRule systemOutRule = new SystemOutRule().enableLog();
+    public final SystemOutRule systemOutRule = new SystemOutRule().enableLog().mute();
+    /**
+     * The System Error rule
+     */
     @Rule
-    public final SystemErrRule systemErrRule = new SystemErrRule().enableLog();
+    public final SystemErrRule systemErrRule = new SystemErrRule().enableLog().mute();
+    /**
+     * The Expected System Exit
+     */
     @Rule
     public final ExpectedSystemExit exit = ExpectedSystemExit.none();
 
@@ -124,7 +237,8 @@ public class CommandLineInterfaceTest {
 
     @Test
     public void testShowProvisionUsageHelp() {
-        exit.checkAssertionAfterwards(() -> assertEquals("Unexpected output from CLI for usage help",
+        exit.checkAssertionAfterwards(() -> assertEquals(
+                "Unexpected output from CLI for provisionconfig usage help",
                 PROVISION_USAGE,
                 systemOutRule.getLog()));
         // With -h arg
@@ -134,7 +248,7 @@ public class CommandLineInterfaceTest {
     @Test
     public void testShowProvisionUsageHelpWithoutHelpArg() {
         exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected output from CLI for usage help",
+            assertEquals("Unexpected output from CLI for provisionconfig usage help",
                     PROVISION_USAGE,
                     systemOutRule.getLog());
             assertEquals("Missing error output",
@@ -144,5 +258,156 @@ public class CommandLineInterfaceTest {
         });
         // With no args
         CommandLineInterface.main(new String[] {PROVISION_COMMAND});
+    }
+
+    @Test
+    public void testShowGenerateCsrUsageHelp() {
+        exit.checkAssertionAfterwards(() -> assertEquals(
+                "Unexpected output from CLI for generatecsr usage help",
+                GENERATE_CSR_USAGE,
+                systemOutRule.getLog()));
+        // With -h arg
+        CommandLineInterface.main(new String[] {GENERATE_CSR_COMMAND, "-h"});
+    }
+
+    @Test
+    public void testShowGenerateCsrUsageHelpWithoutHelpArg() {
+        exit.checkAssertionAfterwards(() -> {
+            assertEquals("Unexpected output from CLI for generatecsr usage help",
+                    GENERATE_CSR_USAGE,
+                    systemOutRule.getLog());
+            assertEquals("Missing error output",
+                    "ERROR: Missing required parameters: CONFIGDIR, COMMON_NAME"
+                            + System.lineSeparator(),
+                    systemErrRule.getLog());
+        });
+        // With no args
+        CommandLineInterface.main(new String[] {GENERATE_CSR_COMMAND});
+    }
+
+    @Test
+    public void testShowUpdateConfigUsageHelp() {
+        exit.checkAssertionAfterwards(() -> assertEquals(
+                "Unexpected output from CLI for generatecsr usage help",
+                UPDATE_CONFIG_USAGE,
+                systemOutRule.getLog()));
+        // With -h arg
+        CommandLineInterface.main(new String[] {UPDATE_CONFIG_COMMAND, "-h"});
+    }
+
+    @Test
+    public void testShowUpdateConfigUsageHelpWithoutHelpArg() {
+        exit.checkAssertionAfterwards(() -> {
+            assertEquals("Unexpected output from CLI for generatecsr usage help",
+                    UPDATE_CONFIG_USAGE,
+                    systemOutRule.getLog());
+            assertEquals("Missing error output",
+                    "ERROR: Missing required parameters: CONFIGDIR, HOSTNAME"
+                            + System.lineSeparator(),
+                    systemErrRule.getLog());
+        });
+        // With no args
+        CommandLineInterface.main(new String[] {UPDATE_CONFIG_COMMAND});
+    }
+
+    private void testGenerateCSR(String[] commandLineArgs, String filePrefix,
+                                 Map<ASN1ObjectIdentifier, String> certificateAttributes,
+                                 List<String> csrSanValues) {
+        exit.checkAssertionAfterwards(() -> {
+
+            File privateKeyFile = new File(TEMP_FILE_DIR_NAME + File.separatorChar + filePrefix + ".key");
+            File csrFile = new File(TEMP_FILE_DIR_NAME + File.separatorChar + filePrefix + ".csr");
+
+            try (FileInputStream csrFileInputStream = new FileInputStream(csrFile);
+                 InputStreamReader csrInputStreamReader = new InputStreamReader(csrFileInputStream);
+                 PemReader csrPemReader = new PemReader(csrInputStreamReader);
+                 FileInputStream privateKeyFileInputStream = new FileInputStream(privateKeyFile);
+                 InputStreamReader privateKeyInputStreamReader = new InputStreamReader(privateKeyFileInputStream);
+                 PEMParser privateKeyPemParser = new PEMParser(privateKeyInputStreamReader)) {
+
+                // Validate private key file
+                assertTrue("The private key file does not exist", privateKeyFile.exists());
+                PemObject privateKeyPemObject = privateKeyPemParser.readPemObject();
+                JcaPEMKeyConverter jcaPEMKeyConverter = new JcaPEMKeyConverter();
+                PrivateKey privateKey = jcaPEMKeyConverter.getPrivateKey(
+                        PrivateKeyInfo.getInstance(ASN1Primitive.fromByteArray(privateKeyPemObject.getContent())));
+                assertEquals("Private Key algorithm is not RSA.", "RSA", privateKey.getAlgorithm());
+
+                // Validate CSR file
+                assertTrue("The CSR file does not exist", csrFile.exists());
+                PemObject csrPemObject = csrPemReader.readPemObject();
+                final PKCS10CertificationRequest csr = new PKCS10CertificationRequest(csrPemObject.getContent());
+
+                X500NameBuilder nameBuilder = new X500NameBuilder(X500Name.getDefaultStyle());
+                for (Map.Entry<ASN1ObjectIdentifier, String> certificateAttribute : certificateAttributes.entrySet()) {
+                    nameBuilder.addRDN(certificateAttribute.getKey(), certificateAttribute.getValue());
+                }
+
+                // Verify CSR subject name
+                assertEquals("The CSR subject name is incorrect", nameBuilder.build(), csr.getSubject());
+
+                if (csrSanValues != null && !csrSanValues.isEmpty()) {
+                    Attribute[] csrAttributes = csr.getAttributes(PKCSObjectIdentifiers.pkcs_9_at_extensionRequest);
+                    if (csrAttributes != null && csrAttributes.length > 0) {
+                        Extensions extensions = Extensions.getInstance(csrAttributes[0].getAttributeValues()[0]);
+                        GeneralNames generalNames =
+                                GeneralNames.fromExtensions(extensions, Extension.subjectAlternativeName);
+
+                        for (GeneralName generalName : generalNames.getNames()) {
+                            if (generalName.getTagNo() == GeneralName.dNSName) {
+                                ASN1Encodable value = generalName.getName();
+                                if (value instanceof ASN1String) {
+                                    assertTrue("SAN value not in expected list",
+                                            csrSanValues.contains(((ASN1String) value).getString()));
+                                }
+                            }
+                        }
+                    }
+                }
+            } finally {
+                FileUtils.deleteDirectory(new File(TEMP_FILE_DIR_NAME));
+            }
+        });
+        CommandLineInterface.main(commandLineArgs);
+    }
+
+    @Test
+    public void testGenerateCsrBasic() {
+
+        testGenerateCSR(new String[] {GENERATE_CSR_COMMAND, TEMP_FILE_DIR_NAME, CSR_COMMON_NAME}, DEFAULT_FILE_PREFIX,
+                Collections.singletonMap(BCStyle.CN, CSR_COMMON_NAME), Collections.EMPTY_LIST);
+    }
+
+    @Test
+    public void testGenerateCsrBasicWithArgs() {
+        final String commonName = "myclient";
+        final String filePrefix = "theclient";
+        final String countyCode = "US";
+        final String state = "OR";
+        final String locality = "Hillsboro";
+        final String organization = "McAfee";
+        final String organizationalUnit = "DXL Teeam";
+        final String email = "test@testm.com";
+        final String san1 = "client1.myorg.com";
+        final String san2 = "client1.myorg.net";
+
+        Map<ASN1ObjectIdentifier, String> certificateOIDs = new HashMap<>();
+        certificateOIDs.put(BCStyle.CN, commonName);
+        certificateOIDs.put(BCStyle.C, countyCode);
+        certificateOIDs.put(BCStyle.EmailAddress, email);
+        certificateOIDs.put(BCStyle.L, locality);
+        certificateOIDs.put(BCStyle.ST, state);
+        certificateOIDs.put(BCStyle.O, organization);
+        certificateOIDs.put(BCStyle.OU, organizationalUnit);
+
+        List<String> csrSanValues = new ArrayList<>();
+        csrSanValues.add(san1);
+        csrSanValues.add(san2);
+
+        testGenerateCSR(new String[] {GENERATE_CSR_COMMAND, TEMP_FILE_DIR_NAME, commonName, "-f", filePrefix,
+                        "--country", countyCode, "--state-or-province", state, "--locality", locality, "--organization",
+                        organization, "--organizational-unit", organizationalUnit, "--email-address", email,
+                        "-s", san1, san2},
+                filePrefix, certificateOIDs, csrSanValues);
     }
 }


### PR DESCRIPTION
- Migrate to Gradle 5.0: In order to support oraclejdk11 Gradle 5.0 is required
- Added more JDK environments for Travis-CI builds
- Switched to having Travis-CI builds use the Java code for provisioning the DXL Client used in testing
- Added more unit tests