### PR TITLE
Add proxy support and migrate to paho.mqtt.java 1.2.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "paho.mqtt.java"]
 	path = paho.mqtt.java
 	url = https://github.com/opendxl-community/paho.mqtt.java.git
-	branch = opendxl-modifications
+	branch = opendxl-modifications-merge-1.2.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ script:
   - ip4=$(/sbin/ip -o -4 addr list eth0 | awk '{print $4}' | cut -d/ -f1)
   - docker ps
   - docker logs squid
-  - java -Dhttps.proxyHost=${ip4} -Dhttps.proxyPort=3128 -Dhttp.proxyHost=${ip4} -Dhttp.proxyPort=3128 -Dhttp.proxyUser=proxyuser -Dhttp.proxyPassword=proxypassword -jar ./build/libs/dxlclient*all.jar provisionconfig clientconfig ${ip4} client -u admin -p password
+  - java -Dhttps.proxyHost=${ip4} -Dhttps.proxyPort=3128 -Dhttps.proxyUser=proxyuser -Dhttps.proxyPassword=proxypassword -jar ./build/libs/dxlclient*all.jar provisionconfig clientconfig ${ip4} client -u admin -p password
   - sed -i -e "s/127.0.0.1;127.0.0.1/127.0.0.1/g" -e "/local/d" -e "/docker/d" clientconfig/dxlclient.config
   - sed -i -e "s/= false/= true/g" clientconfig/dxlclient.config
   - cat clientconfig/dxlclient.config

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
   - docker ps -a
   - mkdir ./squid-proxy-cache
   - htpasswd -b -c ./testing/passwords proxyuser proxypassword
-  - docker run --name squid -d --restart=always --publish 3128:3128 --volume ./testing/squid.conf:/etc/squid/squid.conf --volume ./testing/passwords:/etc/squid/passwords --volume ./squid-proxy-cache:/var/spool/squid sameersbn/squid
+  - docker run --name squid -d --restart=always --publish 3128:3128 --volume ${TRAVIS_BUILD_DIR}/testing/squid.conf:/etc/squid/squid.conf --volume ${TRAVIS_BUILD_DIR}/testing/passwords:/etc/squid/passwords --volume ./squid-proxy-cache:/var/spool/squid sameersbn/squid
   - docker ps -a
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,15 +23,6 @@ before_install:
 
 script:
   - ip4=$(/sbin/ip -o -4 addr list eth0 | awk '{print $4}' | cut -d/ -f1)
-  - java -Dhttps.proxyHost${ip4} -Dhttps.proxyPort=3128 -Dhttp.proxyHost=${ip4} -Dhttp.proxyPort=3128 -Dhttp.proxyUser=proxyuser -Dhttp.proxyPassword=proxypassword -jar ./build/libs/dxlclient*all.jar provisionconfig clientconfig ${ip4} client -u admin -p password
-  - sed -i -e "s/127.0.0.1;127.0.0.1/127.0.0.1/g" -e "/local/d" -e "/docker/d" clientconfig/dxlclient.config
-  - sed -i -e "s/= false/= true/g" -e "s/;8883/;443/g" -e "s/Brokers/BrokersWebSockets/g"  clientconfig/dxlclient.config
-  - echo "[Proxy]" >> clientconfig/dxlclient.config
-  - echo "Address=${ip4}" >> clientconfig/dxlclient.config
-  - echo "Port=3128" >> clientconfig/dxlclient.config
-  - echo "User=proxyuser" >> clientconfig/dxlclient.config
-  - echo "Password=proxypassword" >> clientconfig/dxlclient.config
-  - cat clientconfig/dxlclient.config
-  - cat clientconfig/dxlclient.config
-  - echo Running tests with WebSockets and authenticated proxy
-  - ./gradlew cleanTest test --info --console=plain
+  - curl -x http://proxyuser:proxypassword@${ip4}:3128 -I http://google.com
+  - curl -x http://proxyuser:proxypassword@127.0.0.1:3128 -I http://google.com
+  - - java -Dhttps.proxyHost=127.0.0.1 -Dhttps.proxyPort=3128 -Dhttp.proxyHost=127.0.0.1 -Dhttp.proxyPort=3128 -Dhttp.proxyUser=proxyuser -Dhttp.proxyPassword=proxypassword -jar ./build/libs/dxlclient*all.jar provisionconfig clientconfig ${ip4} client -u admin -p password

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,11 +25,17 @@ script:
   - ip4=$(/sbin/ip -o -4 addr list eth0 | awk '{print $4}' | cut -d/ -f1)
   - java -Dhttps.proxyHost=${ip4} -Dhttps.proxyPort=3128 -Dhttp.proxyHost=${ip4} -Dhttp.proxyPort=3128 -Dhttp.proxyUser=proxyuser -Dhttp.proxyPassword=proxypassword -jar ./build/libs/dxlclient*all.jar provisionconfig clientconfig ${ip4} client -u admin -p password
   - sed -i -e "s/127.0.0.1;127.0.0.1/127.0.0.1/g" -e "/local/d" -e "/docker/d" clientconfig/dxlclient.config
+  - sed -i -e "s/= false/= true/g" clientconfig/dxlclient.config
+  - cat clientconfig/dxlclient.config
   - echo "[Proxy]" >> clientconfig/dxlclient.config
   - echo "Address=${ip4}" >> clientconfig/dxlclient.config
   - echo "Port=3128" >> clientconfig/dxlclient.config
   - echo "User=proxyuser" >> clientconfig/dxlclient.config
   - echo "Password=proxypassword" >> clientconfig/dxlclient.config
   - cat clientconfig/dxlclient.config
+  - echo Running Proxy Usage Verification Test
+  - ./gradlew proxyUsageVerificationTest
+  - docker exec -it squid tail /var/log/squid/access.log
   - echo Running tests with WebSockets and authenticated proxy
   - ./gradlew cleanTest test --info --console=plain
+  - docker exec -it squid tail /var/log/squid/access.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
 
 script:
   - ip4=$(/sbin/ip -o -4 addr list eth0 | awk '{print $4}' | cut -d/ -f1)
-  - java -Dhttps.proxyHost{$ip4} -Dhttps.proxyPort=3128 -Dhttp.proxyHost={$ip4} -Dhttp.proxyPort=3128 -Dhttp.proxyUser=proxyuser -Dhttp.proxyPassword=proxypassword -jar ./build/libs/dxlclient*all.jar provisionconfig clientconfig {$ip4} client -u admin -p password
+  - java -Dhttps.proxyHost${ip4} -Dhttps.proxyPort=3128 -Dhttp.proxyHost=${ip4} -Dhttp.proxyPort=3128 -Dhttp.proxyUser=proxyuser -Dhttp.proxyPassword=proxypassword -jar ./build/libs/dxlclient*all.jar provisionconfig clientconfig ${ip4} client -u admin -p password
   - sed -i -e "s/127.0.0.1;127.0.0.1/127.0.0.1/g" -e "/local/d" -e "/docker/d" clientconfig/dxlclient.config
   - sed -i -e "s/= false/= true/g" -e "s/;8883/;443/g" -e "s/Brokers/BrokersWebSockets/g"  clientconfig/dxlclient.config
   - echo "[Proxy]" >> clientconfig/dxlclient.config

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,14 @@ script:
   - docker ps
   - java -Dhttps.proxyHost=${ip4} -Dhttps.proxyPort=3128 -Dhttps.proxyUser=proxyuser -Dhttps.proxyPassword=proxypassword -jar ./build/libs/dxlclient*all.jar provisionconfig clientconfig ${ip4} client -u admin -p password
   - sed -i -e "s/127.0.0.1;127.0.0.1/127.0.0.1/g" -e "/local/d" -e "/docker/d" clientconfig/dxlclient.config
+  - cat clientconfig/dxlclient.config
+  - echo Running tests with MQTT
+  - ./gradlew test --info --console=plain
   - sed -i -e "s/= false/= true/g" clientconfig/dxlclient.config
   - cat clientconfig/dxlclient.config
+  - echo Running tests with WebSockets and no proxy
+  - ./gradlew cleanTest test --info --console=plain
+  - echo Updating dxlclient.config to include proxy information
   - echo "[Proxy]" >> clientconfig/dxlclient.config
   - echo "Address=${ip4}" >> clientconfig/dxlclient.config
   - echo "Port=3128" >> clientconfig/dxlclient.config
@@ -36,7 +42,7 @@ script:
   - echo "Password=proxypassword" >> clientconfig/dxlclient.config
   - cat clientconfig/dxlclient.config
   - echo Running Proxy Usage Verification Test
-  - ./gradlew proxyUsageVerificationTest -i
+  - ./gradlew proxyUsageVerificationTest
   - docker exec -it squid tail /var/log/squid/access.log
   - echo Running tests with WebSockets and authenticated proxy
   - ./gradlew cleanTest test --info --console=plain

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
   - sudo apt-get install -y apache2-utils
   - docker pull opendxl/opendxl-broker
   - docker pull sameersbn/squid
-  - docker run -d -p 127.0.0.1:8883:8883 -p 127.0.0.1:8443:8443 -p 127.0.0.1:443:443 opendxl/opendxl-broker
+  - docker run -d -p 8883:8883 -p 8443:8443 -p 443:443 opendxl/opendxl-broker
   - docker ps -a
   - mkdir ./squid-proxy-cache
   - htpasswd -b -c ./testing/passwords proxyuser proxypassword
@@ -22,15 +22,14 @@ before_install:
   - docker ps -a
 
 script:
-  - java -Dhttps.proxyHost=127.0.0.1 -Dhttps.proxyPort=3128 -Dhttp.proxyHost=127.0.0.1 -Dhttp.proxyPort=3128 -Dhttp.proxyUser=proxyuser -Dhttp.proxyPassword=proxypassword -jar ./build/libs/dxlclient*all.jar provisionconfig clientconfig 127.0.0.1 client -u admin -p password
+  - ip4=$(/sbin/ip -o -4 addr list eth0 | awk '{print $4}' | cut -d/ -f1)
+  - java -Dhttps.proxyHost=${ip4} -Dhttps.proxyPort=3128 -Dhttp.proxyHost=${ip4} -Dhttp.proxyPort=3128 -Dhttp.proxyUser=proxyuser -Dhttp.proxyPassword=proxypassword -jar ./build/libs/dxlclient*all.jar provisionconfig clientconfig ${ip4} client -u admin -p password
   - sed -i -e "s/127.0.0.1;127.0.0.1/127.0.0.1/g" -e "/local/d" -e "/docker/d" clientconfig/dxlclient.config
-  - sed -i -e "s/= false/= true/g" -e "s/;8883/;443/g" -e "s/Brokers/BrokersWebSockets/g"  clientconfig/dxlclient.config
   - echo "[Proxy]" >> clientconfig/dxlclient.config
-  - echo "Address=127.0.0.1" >> clientconfig/dxlclient.config
+  - echo "Address=${ip4}" >> clientconfig/dxlclient.config
   - echo "Port=3128" >> clientconfig/dxlclient.config
   - echo "User=proxyuser" >> clientconfig/dxlclient.config
   - echo "Password=proxypassword" >> clientconfig/dxlclient.config
-  - cat clientconfig/dxlclient.config
   - cat clientconfig/dxlclient.config
   - echo Running tests with WebSockets and authenticated proxy
   - ./gradlew cleanTest test --info --console=plain

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ before_install:
 script:
   - ip4=$(/sbin/ip -o -4 addr list eth0 | awk '{print $4}' | cut -d/ -f1)
   - docker ps
+  - docker logs squid
   - java -Dhttps.proxyHost=${ip4} -Dhttps.proxyPort=3128 -Dhttp.proxyHost=${ip4} -Dhttp.proxyPort=3128 -Dhttp.proxyUser=proxyuser -Dhttp.proxyPassword=proxypassword -jar ./build/libs/dxlclient*all.jar provisionconfig clientconfig ${ip4} client -u admin -p password
   - sed -i -e "s/127.0.0.1;127.0.0.1/127.0.0.1/g" -e "/local/d" -e "/docker/d" clientconfig/dxlclient.config
   - sed -i -e "s/= false/= true/g" clientconfig/dxlclient.config

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,12 +22,11 @@ before_install:
   - docker ps -a
 
 script:
-  - ip4=$(/sbin/ip -o -4 addr list eth0 | awk '{print $4}' | cut -d/ -f1)
   - java -Dhttps.proxyHost=127.0.0.1 -Dhttps.proxyPort=3128 -Dhttp.proxyHost=127.0.0.1 -Dhttp.proxyPort=3128 -Dhttp.proxyUser=proxyuser -Dhttp.proxyPassword=proxypassword -jar ./build/libs/dxlclient*all.jar provisionconfig clientconfig 127.0.0.1 client -u admin -p password
   - sed -i -e "s/127.0.0.1;127.0.0.1/127.0.0.1/g" -e "/local/d" -e "/docker/d" clientconfig/dxlclient.config
   - sed -i -e "s/= false/= true/g" -e "s/;8883/;443/g" -e "s/Brokers/BrokersWebSockets/g"  clientconfig/dxlclient.config
   - echo "[Proxy]" >> clientconfig/dxlclient.config
-  - echo "Address=${ip4}" >> clientconfig/dxlclient.config
+  - echo "Address=127.0.0.1" >> clientconfig/dxlclient.config
   - echo "Port=3128" >> clientconfig/dxlclient.config
   - echo "User=proxyuser" >> clientconfig/dxlclient.config
   - echo "Password=proxypassword" >> clientconfig/dxlclient.config

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ jdk:
   - oraclejdk8
 
 before_install:
+  - sudo apt-get update
+  - sudo apt-get install -y apache2-utils
   - docker pull opendxl/opendxl-broker
   - docker pull sameersbn/squid
   - docker run -d -p 127.0.0.1:8883:8883 -p 127.0.0.1:8443:8443 -p 127.0.0.1:443:443 opendxl/opendxl-broker

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,16 +11,27 @@ jdk:
 
 before_install:
   - docker pull opendxl/opendxl-broker
+  - docker pull sameersbn/squid
   - docker run -d -p 127.0.0.1:8883:8883 -p 127.0.0.1:8443:8443 -p 127.0.0.1:443:443 opendxl/opendxl-broker
+  - docker ps -a
+  - mkdir ./squid-proxy-cache
+  - mkdir /etc/squid/
+  - htpasswd -b -c /etc/squid/passwords proxyuser proxypassword
+  - cp ./testing/squid.conf /etc/squid/squid.conf
+  - docker run --name squid -d --restart=always --publish 3128:3128 --volume /etc/squid/squid.conf:/etc/squid/squid.conf --volume /etc/squid/passwords:/etc/squid/passwords --volume ./squid-proxy-cache:/var/spool/squid sameersbn/squid
   - docker ps -a
 
 script:
-  - java -jar ./build/libs/dxlclient*all.jar provisionconfig clientconfig 127.0.0.1 client -u admin -p password
+  - ip4=$(/sbin/ip -o -4 addr list eth0 | awk '{print $4}' | cut -d/ -f1)
+  - java -Dhttps.proxyHost{$ip4} -Dhttps.proxyPort=3128 -Dhttp.proxyHost={$ip4} -Dhttp.proxyPort=3128 -Dhttp.proxyUser=proxyuser -Dhttp.proxyPassword=proxypassword -jar ./build/libs/dxlclient*all.jar provisionconfig clientconfig {$ip4} client -u admin -p password
   - sed -i -e "s/127.0.0.1;127.0.0.1/127.0.0.1/g" -e "/local/d" -e "/docker/d" clientconfig/dxlclient.config
-  - cat clientconfig/dxlclient.config
-  - echo Running tests with MQTT
-  - ./gradlew test --info --console=plain
   - sed -i -e "s/= false/= true/g" -e "s/;8883/;443/g" -e "s/Brokers/BrokersWebSockets/g"  clientconfig/dxlclient.config
+  - echo "[Proxy]" >> clientconfig/dxlclient.config
+  - echo "Address=${ip4}" >> clientconfig/dxlclient.config
+  - echo "Port=3128" >> clientconfig/dxlclient.config
+  - echo "User=proxyuser" >> clientconfig/dxlclient.config
+  - echo "Password=proxypassword" >> clientconfig/dxlclient.config
   - cat clientconfig/dxlclient.config
-  - echo Running tests with WebSockets
+  - cat clientconfig/dxlclient.config
+  - echo Running tests with WebSockets and authenticated proxy
   - ./gradlew cleanTest test --info --console=plain

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ before_install:
 script:
   - ip4=$(/sbin/ip -o -4 addr list eth0 | awk '{print $4}' | cut -d/ -f1)
   - docker ps
-  - docker logs squid
   - java -Dhttps.proxyHost=${ip4} -Dhttps.proxyPort=3128 -Dhttps.proxyUser=proxyuser -Dhttps.proxyPassword=proxypassword -jar ./build/libs/dxlclient*all.jar provisionconfig clientconfig ${ip4} client -u admin -p password
   - sed -i -e "s/127.0.0.1;127.0.0.1/127.0.0.1/g" -e "/local/d" -e "/docker/d" clientconfig/dxlclient.config
   - sed -i -e "s/= false/= true/g" clientconfig/dxlclient.config
@@ -37,7 +36,7 @@ script:
   - echo "Password=proxypassword" >> clientconfig/dxlclient.config
   - cat clientconfig/dxlclient.config
   - echo Running Proxy Usage Verification Test
-  - ./gradlew proxyUsageVerificationTest
+  - ./gradlew proxyUsageVerificationTest -i
   - docker exec -it squid tail /var/log/squid/access.log
   - echo Running tests with WebSockets and authenticated proxy
   - ./gradlew cleanTest test --info --console=plain

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,15 @@ before_install:
 
 script:
   - ip4=$(/sbin/ip -o -4 addr list eth0 | awk '{print $4}' | cut -d/ -f1)
-  - curl -x http://proxyuser:proxypassword@${ip4}:3128 -I http://google.com
-  - curl -x http://proxyuser:proxypassword@127.0.0.1:3128 -I http://google.com
   - java -Dhttps.proxyHost=127.0.0.1 -Dhttps.proxyPort=3128 -Dhttp.proxyHost=127.0.0.1 -Dhttp.proxyPort=3128 -Dhttp.proxyUser=proxyuser -Dhttp.proxyPassword=proxypassword -jar ./build/libs/dxlclient*all.jar provisionconfig clientconfig 127.0.0.1 client -u admin -p password
+  - sed -i -e "s/127.0.0.1;127.0.0.1/127.0.0.1/g" -e "/local/d" -e "/docker/d" clientconfig/dxlclient.config
+  - sed -i -e "s/= false/= true/g" -e "s/;8883/;443/g" -e "s/Brokers/BrokersWebSockets/g"  clientconfig/dxlclient.config
+  - echo "[Proxy]" >> clientconfig/dxlclient.config
+  - echo "Address=${ip4}" >> clientconfig/dxlclient.config
+  - echo "Port=3128" >> clientconfig/dxlclient.config
+  - echo "User=proxyuser" >> clientconfig/dxlclient.config
+  - echo "Password=proxypassword" >> clientconfig/dxlclient.config
   - cat clientconfig/dxlclient.config
+  - cat clientconfig/dxlclient.config
+  - echo Running tests with WebSockets and authenticated proxy
+  - ./gradlew cleanTest test --info --console=plain

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
   - docker ps -a
   - mkdir ./squid-proxy-cache
   - htpasswd -b -c ./testing/passwords proxyuser proxypassword
-  - docker run --name squid -d --restart=always --publish 3128:3128 --volume ${TRAVIS_BUILD_DIR}/testing/squid.conf:/etc/squid/squid.conf --volume ${TRAVIS_BUILD_DIR}/testing/passwords:/etc/squid/passwords --volume ./squid-proxy-cache:/var/spool/squid sameersbn/squid
+  - docker run --name squid -d --restart=always --publish 3128:3128 --volume ${TRAVIS_BUILD_DIR}/testing/squid.conf:/etc/squid/squid.conf --volume ${TRAVIS_BUILD_DIR}/testing/passwords:/etc/squid/passwords --volume ${TRAVIS_BUILD_DIR}/squid-proxy-cache:/var/spool/squid sameersbn/squid
   - docker ps -a
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,13 +16,15 @@ before_install:
   - docker pull sameersbn/squid
   - docker run -d -p 8883:8883 -p 8443:8443 -p 443:443 opendxl/opendxl-broker
   - docker ps -a
-  - mkdir ./squid-proxy-cache
-  - htpasswd -b -c ./testing/passwords proxyuser proxypassword
+  - mkdir squid-proxy-cache
+  - htpasswd -b -c ${TRAVIS_BUILD_DIR}/testing/passwords proxyuser proxypassword
+  - cat ${TRAVIS_BUILD_DIR}/testing/passwords
   - docker run --name squid -d --restart=always --publish 3128:3128 --volume ${TRAVIS_BUILD_DIR}/testing/squid.conf:/etc/squid/squid.conf --volume ${TRAVIS_BUILD_DIR}/testing/passwords:/etc/squid/passwords --volume ${TRAVIS_BUILD_DIR}/squid-proxy-cache:/var/spool/squid sameersbn/squid
   - docker ps -a
 
 script:
   - ip4=$(/sbin/ip -o -4 addr list eth0 | awk '{print $4}' | cut -d/ -f1)
+  - docker ps
   - java -Dhttps.proxyHost=${ip4} -Dhttps.proxyPort=3128 -Dhttp.proxyHost=${ip4} -Dhttp.proxyPort=3128 -Dhttp.proxyUser=proxyuser -Dhttp.proxyPassword=proxypassword -jar ./build/libs/dxlclient*all.jar provisionconfig clientconfig ${ip4} client -u admin -p password
   - sed -i -e "s/127.0.0.1;127.0.0.1/127.0.0.1/g" -e "/local/d" -e "/docker/d" clientconfig/dxlclient.config
   - sed -i -e "s/= false/= true/g" clientconfig/dxlclient.config

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,4 +25,5 @@ script:
   - ip4=$(/sbin/ip -o -4 addr list eth0 | awk '{print $4}' | cut -d/ -f1)
   - curl -x http://proxyuser:proxypassword@${ip4}:3128 -I http://google.com
   - curl -x http://proxyuser:proxypassword@127.0.0.1:3128 -I http://google.com
-  - - java -Dhttps.proxyHost=127.0.0.1 -Dhttps.proxyPort=3128 -Dhttp.proxyHost=127.0.0.1 -Dhttp.proxyPort=3128 -Dhttp.proxyUser=proxyuser -Dhttp.proxyPassword=proxypassword -jar ./build/libs/dxlclient*all.jar provisionconfig clientconfig ${ip4} client -u admin -p password
+  - java -Dhttps.proxyHost=127.0.0.1 -Dhttps.proxyPort=3128 -Dhttp.proxyHost=127.0.0.1 -Dhttp.proxyPort=3128 -Dhttp.proxyUser=proxyuser -Dhttp.proxyPassword=proxypassword -jar ./build/libs/dxlclient*all.jar provisionconfig clientconfig 127.0.0.1 client -u admin -p password
+  - cat clientconfig/dxlclient.config

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,8 @@ before_install:
   - docker run -d -p 127.0.0.1:8883:8883 -p 127.0.0.1:8443:8443 -p 127.0.0.1:443:443 opendxl/opendxl-broker
   - docker ps -a
   - mkdir ./squid-proxy-cache
-  - mkdir /etc/squid/
-  - htpasswd -b -c /etc/squid/passwords proxyuser proxypassword
-  - cp ./testing/squid.conf /etc/squid/squid.conf
-  - docker run --name squid -d --restart=always --publish 3128:3128 --volume /etc/squid/squid.conf:/etc/squid/squid.conf --volume /etc/squid/passwords:/etc/squid/passwords --volume ./squid-proxy-cache:/var/spool/squid sameersbn/squid
+  - htpasswd -b -c ./testing/passwords proxyuser proxypassword
+  - docker run --name squid -d --restart=always --publish 3128:3128 --volume ./testing/squid.conf:/etc/squid/squid.conf --volume ./testing/passwords:/etc/squid/passwords --volume ./squid-proxy-cache:/var/spool/squid sameersbn/squid
   - docker ps -a
 
 script:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.opendxl/dxlclient/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.opendxl/dxlclient)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![Build Status](https://travis-ci.org/opendxl/opendxl-client-java.png?branch=master)](https://travis-ci.org/opendxl/opendxl-client-java)
+[![Build Status](https://travis-ci.org/krisleonard-mcafee/opendxl-client-java.svg?branch=master)](https://travis-ci.org/krisleonard-mcafee/opendxl-client-java)
 
 ## Overview
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.opendxl/dxlclient/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.opendxl/dxlclient)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![Build Status](https://travis-ci.org/krisleonard-mcafee/opendxl-client-java.svg?branch=master)](https://travis-ci.org/krisleonard-mcafee/opendxl-client-java)
+[![Build Status](https://travis-ci.org/opendxl/opendxl-client-java.png?branch=master)](https://travis-ci.org/opendxl/opendxl-client-java)
 
 ## Overview
 

--- a/build.gradle
+++ b/build.gradle
@@ -256,8 +256,17 @@ assemble.dependsOn(replaceVersionInREADME)
 
 test {
     systemProperty 'clientConfig', "${rootDir}/clientconfig/dxlclient.config"
+    
+    // Exclude the Proxy Usage Verification Test
+    exclude "**/ProxyUsageVerificationTest.class"
 //    filter {
 //        //specific test method
 //        includeTestsMatching "com.opendxl.client.RegisterServiceTest"
 //    }
+}
+
+// Task for verifying proxy usage
+task proxyUsageVerificationTest(type:Test) {
+    systemProperty 'clientConfig', "${rootDir}/clientconfig/dxlclient.config"
+    include "**/ProxyUsageVerificationTest.class"
 }

--- a/clientconfig/dxlclient.config.template
+++ b/clientconfig/dxlclient.config.template
@@ -18,3 +18,13 @@ unique_broker_id_1=unique_broker_id_1;@BROKER_PORT@;@BROKER_HOSTNAME@;@BROKER_IP
 
 [BrokersWebSockets]
 unique_websocket_broker_id_1=unique_websocket_broker_id_1;@BROKER_WEBSOCKET_PORT@;@BROKER_HOSTNAME@;@BROKER_IP@
+
+# The [Proxy] section is optional and only applies to WebSocket connections. This section
+# will not be used when the OpenDXL Java Client connects to a DXL Broker via MQTT. It should be used when the
+# OpenDXL Java Client WebSocket connection to a DXL Broker must be routed through a proxy. The user and password
+# settings are not required if the proxy does not require authentication.
+[Proxy]
+Address=<Proxy host name or IP address>
+Port=<Proxy port>
+User=<User name required for authentication with the Proxy>
+Password=<Password required for authentication with the Proxy>

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -66,6 +66,11 @@
         <!-- See http://checkstyle.sf.net/config_sizes.html -->
         <module name="LineLength">
             <property name="max" value="120"/>
+            <!--
+            Ignore Javadoc comments since references to other elements (@see
+            tag, etc.) may get rather long and should not be truncated.
+            -->
+            <property name="ignorePattern" value="^\s*\*\s*[^\s]+.+$"/>
         </module>
         <module name="MethodLength">
             <property name="max" value="200"/>

--- a/docs/advancedcliprovisioning.rst
+++ b/docs/advancedcliprovisioning.rst
@@ -8,6 +8,19 @@ Refer to :doc:`basiccliprovisioning` for basic usage details.
 
 .. _subject-attributes-label:
 
+Routing provisioning operation through a proxy
+**********************************************
+
+If the remote call to a provisioning server (ePO or OpenDXL Broker) must be routed through a proxy, then use standard Java system
+properties to declare the proxy host, port, user name, and password. (`<https://docs.oracle.com/javase/8/docs/technotes/guides/net/proxies.html>`_)
+
+For example:
+
+    .. parsed-literal::
+
+        java -Dhttps.proxyHost=proxy.mycompany.com -Dhttps.proxyPort=3128 -Dhttp.proxyHost=proxy.mycompany.com -Dhttp.proxyPort=3128 -Dhttp.proxyUser=proxyUser -Dhttp.proxyPassword=proxyPassword -jar dxlclient-\ |version|\-all.jar provisionconfig config myserver client1
+
+
 Additional Certificate Signing Request (CSR) Information
 ********************************************************
 

--- a/docs/advancedcliprovisioning.rst
+++ b/docs/advancedcliprovisioning.rst
@@ -12,13 +12,13 @@ Routing provisioning operation through a proxy
 **********************************************
 
 If the remote call to a provisioning server (ePO or OpenDXL Broker) must be routed through a proxy, then use standard Java system
-properties to declare the proxy host, port, user name, and password. (`<https://docs.oracle.com/javase/8/docs/technotes/guides/net/proxies.html>`_)
+properties to declare the https proxy host, port, user name, and password. (`<https://docs.oracle.com/javase/8/docs/technotes/guides/net/proxies.html>`_)
 
 For example:
 
     .. parsed-literal::
 
-        java -Dhttps.proxyHost=proxy.mycompany.com -Dhttps.proxyPort=3128 -Dhttp.proxyHost=proxy.mycompany.com -Dhttp.proxyPort=3128 -Dhttp.proxyUser=proxyUser -Dhttp.proxyPassword=proxyPassword -jar dxlclient-\ |version|\-all.jar provisionconfig config myserver client1
+        java -Dhttps.proxyHost=proxy.mycompany.com -Dhttps.proxyPort=3128 -Dhttps.proxyUser=proxyUser -Dhttps.proxyPassword=proxyPassword -jar dxlclient-\ |version|\-all.jar provisionconfig config myserver client1
 
 
 Additional Certificate Signing Request (CSR) Information

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,7 +3,7 @@ import sys, os
 from recommonmark.parser import CommonMarkParser
 
 project = u'OpenDXL Java SDK'
-copyright = u'2018, McAfee LLC'
+copyright = u'2019, McAfee LLC'
 
 with open('../VERSION', 'r') as content_file:
     VERSION = content_file.read()

--- a/docs/epoexternalcertissuance.rst
+++ b/docs/epoexternalcertissuance.rst
@@ -51,6 +51,12 @@ The following steps walk through the process of populating this file:
            unique_websocket_broker_id_1=unique_websocket_broker_id_1;broker_websocket_port_1;broker_hostname_1;broker_ip_1
            unique_websocket_broker_id_2=unique_websocket_broker_id_2;broker_websocket_port_2;broker_hostname_2;broker_ip_2
 
+           [Proxy]
+           Address=<Proxy host name or IP address>
+           Port=<Proxy port>
+           User=<User name required for authentication with the Proxy>
+           Password=<Password required for authentication with the Proxy>
+
 2. Optionally update the ``UseWebSockets`` value to indicate if the OpenDXL Java Client should connect to DXL Brokers
    via WebSockets. This flag will override the default behavior which is the following:
 
@@ -85,6 +91,12 @@ The following steps walk through the process of populating this file:
            unique_websocket_broker_id_1=unique_websocket_broker_id_1;broker_websocket_port_1;broker_hostname_1;broker_ip_1
            unique_websocket_broker_id_2=unique_websocket_broker_id_2;broker_websocket_port_2;broker_hostname_2;broker_ip_2
 
+           [Proxy]
+           Address=<Proxy host name or IP address>
+           Port=<Proxy port>
+           User=<User name required for authentication with the Proxy>
+           Password=<Password required for authentication with the Proxy>
+
 4. Update the ``BrokerCertChain`` value to point to the Broker Certificates file (``brokercerts.crt``)
    that was created when exporting the Broker Certificates.
 
@@ -109,6 +121,12 @@ The following steps walk through the process of populating this file:
            [BrokersWebSockets]
            unique_websocket_broker_id_1=unique_websocket_broker_id_1;broker_websocket_port_1;broker_hostname_1;broker_ip_1
            unique_websocket_broker_id_2=unique_websocket_broker_id_2;broker_websocket_port_2;broker_hostname_2;broker_ip_2
+
+           [Proxy]
+           Address=<Proxy host name or IP address>
+           Port=<Proxy port>
+           User=<User name required for authentication with the Proxy>
+           Password=<Password required for authentication with the Proxy>
 
 5. Update the ``[Brokers]`` and ``[BrokersWebSockets]`` sections to include the contents of the broker
    list file (``brokerlist.properties``) that was created when exporting the Broker List.
@@ -135,4 +153,41 @@ The following steps walk through the process of populating this file:
            {5d73b77f-8c4b-4ae0-b437-febd12facfd4}={5d73b77f-8c4b-4ae0-b437-febd12facfd4};443;mybroker.mcafee.com;192.168.1.12
            {24397e4d-645f-4f2f-974f-f98c55bdddf7}={24397e4d-645f-4f2f-974f-f98c55bdddf7};443;mybroker2.mcafee.com;192.168.1.13
 
-6. At this point you can run the samples included with the Java SDK.
+           [Proxy]
+           Address=<Proxy host name or IP address>
+           Port=<Proxy port>
+           User=<User name required for authentication with the Proxy>
+           Password=<Password required for authentication with the Proxy>
+
+6. Optionally update the ``[Proxy]`` section to have the required host name or IP address, port, user name, and 
+   password of the proxy that WebSocket connections to DXL Brokers will be routed through. These settings are only
+   used when the OpenDXL Java Client will make WebSocket connections to DXL Brokers. The ``User`` and ``Password``
+   values not required if the proxy does not require authentication.
+
+   After completing this step the contents of the configuration file should look similar to:
+
+       .. parsed-literal::
+
+          [General]
+          UseWebSockets=false
+
+          [Certs]
+          BrokerCertChain=c:\\certificates\\brokercerts.crt
+          CertFile=c:\\certificates\\client.crt
+          PrivateKey=c:\\certificates\\client.key
+
+          [Brokers]
+          {5d73b77f-8c4b-4ae0-b437-febd12facfd4}={5d73b77f-8c4b-4ae0-b437-febd12facfd4};8883;mybroker.mcafee.com;192.168.1.12
+          {24397e4d-645f-4f2f-974f-f98c55bdddf7}={24397e4d-645f-4f2f-974f-f98c55bdddf7};8883;mybroker2.mcafee.com;192.168.1.13
+
+          [BrokersWebSockets]
+          {5d73b77f-8c4b-4ae0-b437-febd12facfd4}={5d73b77f-8c4b-4ae0-b437-febd12facfd4};443;mybroker.mcafee.com;192.168.1.12
+          {24397e4d-645f-4f2f-974f-f98c55bdddf7}={24397e4d-645f-4f2f-974f-f98c55bdddf7};443;mybroker2.mcafee.com;192.168.1.13
+
+          [Proxy]
+          Address=proxy.mycompany.com
+          Port=3128
+          User=proxyUser
+          Password=proxyPassword
+
+7. At this point you can run the samples included with the Java SDK.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -50,6 +50,13 @@ External Certificate Authority (CA)
 
         epoexternalcertissuance
 
+WebSocket and Proxy Support
+    .. toctree::
+        :maxdepth: 1
+
+        websocketsupport
+        proxysupport
+
 API Documentation
 -----------------
 

--- a/docs/proxysupport.rst
+++ b/docs/proxysupport.rst
@@ -1,0 +1,41 @@
+Proxy Support
+=============
+
+To have the OpenDXL Java Client connect to DXL Brokers via a proxy set ``UseWebSockets`` setting to ``true`` and set
+the proxy host name or IP address, port, user name, and password in the ``dxlclient.config`` file under the
+``[Proxy]`` section. The ``[Proxy]`` is optional and if it does not exist or the values under it are blank in the
+``dxlclient.config``, then the OpenDXL Java Client will not use a proxy when connecting to the DXL Brokers listed under
+the ``[BrokersWebSockets]`` section. The ``User`` and ``Password`` settings are only required if the proxy requires
+authentication.
+
+       .. parsed-literal::
+
+          [General]
+          UseWebSockets=true
+
+          [Certs]
+          BrokerCertChain=c:\\certificates\\brokercerts.crt
+          CertFile=c:\\certificates\\client.crt
+          PrivateKey=c:\\certificates\\client.key
+
+          [Brokers]
+          {5d73b77f-8c4b-4ae0-b437-febd12facfd4}={5d73b77f-8c4b-4ae0-b437-febd12facfd4};8883;mybroker.mcafee.com;192.168.1.12
+          {24397e4d-645f-4f2f-974f-f98c55bdddf7}={24397e4d-645f-4f2f-974f-f98c55bdddf7};8883;mybroker2.mcafee.com;192.168.1.13
+
+          [BrokersWebSockets]
+          {5d73b77f-8c4b-4ae0-b437-febd12facfd4}={5d73b77f-8c4b-4ae0-b437-febd12facfd4};443;mybroker.mcafee.com;192.168.1.12
+          {24397e4d-645f-4f2f-974f-f98c55bdddf7}={24397e4d-645f-4f2f-974f-f98c55bdddf7};443;mybroker2.mcafee.com;192.168.1.13
+
+          [Proxy]
+          Address=proxy.mycompany.com
+          Port=3128
+          User=proxyUser
+          Password=proxyPassword
+
+.. note::
+
+    In order to use the ``[Proxy]`` section settings, the ``UseWebSockets`` setting must also be set to ``true``. The
+    OpenDXL Java Client will only use proxy settings when connecting to DXL Brokers via WebSockets.
+
+
+

--- a/docs/updatingconfigfromcli.rst
+++ b/docs/updatingconfigfromcli.rst
@@ -94,3 +94,16 @@ The name of the truststore file should be supplied along with the option:
 
         Ensure that the ``-all`` version of the dxlclient ``.jar`` file is specified.
 
+Routing client configuration update operation through a proxy
+*************************************************************
+
+If the remote call to a provisioning server (ePO or OpenDXL Broker) used during a client configuration update must be
+routed through a proxy, then use standard Java system properties to declare the proxy host, port, user name,
+and password. (`<https://docs.oracle.com/javase/8/docs/technotes/guides/net/proxies.html>`_)
+
+For example:
+
+    .. parsed-literal::
+
+        java -Dhttps.proxyHost=proxy.mycompany.com -Dhttps.proxyPort=3128 -Dhttp.proxyHost=proxy.mycompany.com -Dhttp.proxyPort=3128 -Dhttp.proxyUser=proxyUser -Dhttp.proxyPassword=proxyPassword -jar dxlclient-\ |version|\-all.jar updateconfig config myserver
+

--- a/docs/updatingconfigfromcli.rst
+++ b/docs/updatingconfigfromcli.rst
@@ -98,12 +98,12 @@ Routing client configuration update operation through a proxy
 *************************************************************
 
 If the remote call to a provisioning server (ePO or OpenDXL Broker) used during a client configuration update must be
-routed through a proxy, then use standard Java system properties to declare the proxy host, port, user name,
+routed through a proxy, then use standard Java system properties to declare the https proxy host, port, user name,
 and password. (`<https://docs.oracle.com/javase/8/docs/technotes/guides/net/proxies.html>`_)
 
 For example:
 
     .. parsed-literal::
 
-        java -Dhttps.proxyHost=proxy.mycompany.com -Dhttps.proxyPort=3128 -Dhttp.proxyHost=proxy.mycompany.com -Dhttp.proxyPort=3128 -Dhttp.proxyUser=proxyUser -Dhttp.proxyPassword=proxyPassword -jar dxlclient-\ |version|\-all.jar updateconfig config myserver
+        java -Dhttps.proxyHost=proxy.mycompany.com -Dhttps.proxyPort=3128 -Dhttps.proxyUser=proxyUser -Dhttps.proxyPassword=proxyPassword -jar dxlclient-\ |version|\-all.jar updateconfig config myserver
 

--- a/docs/websocketsupport.rst
+++ b/docs/websocketsupport.rst
@@ -1,0 +1,36 @@
+WebSocket Support
+=================
+
+The OpenDXL Java Client will connect to DXL Brokers via WebSockets when the ``UseWebSockets`` setting is set to ``true``
+in the ``dxlclient.config`` file.
+
+       .. parsed-literal::
+
+          [General]
+          UseWebSockets=true
+
+          [Certs]
+          BrokerCertChain=c:\\certificates\\brokercerts.crt
+          CertFile=c:\\certificates\\client.crt
+          PrivateKey=c:\\certificates\\client.key
+
+          [Brokers]
+          {5d73b77f-8c4b-4ae0-b437-febd12facfd4}={5d73b77f-8c4b-4ae0-b437-febd12facfd4};8883;mybroker.mcafee.com;192.168.1.12
+          {24397e4d-645f-4f2f-974f-f98c55bdddf7}={24397e4d-645f-4f2f-974f-f98c55bdddf7};8883;mybroker2.mcafee.com;192.168.1.13
+
+          [BrokersWebSockets]
+          {5d73b77f-8c4b-4ae0-b437-febd12facfd4}={5d73b77f-8c4b-4ae0-b437-febd12facfd4};443;mybroker.mcafee.com;192.168.1.12
+          {24397e4d-645f-4f2f-974f-f98c55bdddf7}={24397e4d-645f-4f2f-974f-f98c55bdddf7};443;mybroker2.mcafee.com;192.168.1.13
+
+          [Proxy]
+          Address=proxy.mycompany.com
+          Port=3128
+          User=proxyUser
+          Password=proxyPassword
+
+
+When the ``UseWebSockets`` setting is set to ``true``, the OpenDXL Java Client will connect to the DXL Brokers
+listed in the ``[BrokersWebSockets]`` sections via WebSockets.
+
+If ``UseWebSockets`` setting is set to ``false`` or does not exist in the ``dxlclient.config`` file, then the
+OpenDXL Java Client will connect to the DXL Brokers listed in the ``[Brokers]`` section via MQTT.

--- a/src/main/java/com/opendxl/client/DxlClient.java
+++ b/src/main/java/com/opendxl/client/DxlClient.java
@@ -1370,8 +1370,15 @@ public class DxlClient implements AutoCloseable {
                     Authenticator.setDefault(new Authenticator() {
                         @Override
                         protected PasswordAuthentication getPasswordAuthentication() {
-                            return new PasswordAuthentication(
-                                getConfig().getProxyUserName(), getConfig().getProxyPassword());
+                            // Only use the proxy username and password in the config if the requesting host and port
+                            // matches the proxy host address and port in the config
+                            if (getRequestingHost().equalsIgnoreCase(getConfig().getProxyAddress())
+                                && getRequestingPort() == getConfig().getProxyPort()) {
+                                return new PasswordAuthentication(
+                                    getConfig().getProxyUserName(), getConfig().getProxyPassword());
+                            }
+
+                            return null;
                         }
                     });
                 }

--- a/src/main/java/com/opendxl/client/DxlClient.java
+++ b/src/main/java/com/opendxl/client/DxlClient.java
@@ -1254,7 +1254,7 @@ public class DxlClient implements AutoCloseable {
         try {
             if (ks != null && this.sslSocketFactoryCallback == null) {
                 this.socketFactory = SSLValidationSocketFactory.newInstance(ks, DxlClientConfig.KS_PASS,
-                    config.getProxyAddress(), config.getProxyPort(),
+                    config.isUseWebSockets(), config.getProxyAddress(), config.getProxyPort(),
                     config.getProxyUserName(), config.getProxyPassword());
             }
             //

--- a/src/main/java/com/opendxl/client/DxlClient.java
+++ b/src/main/java/com/opendxl/client/DxlClient.java
@@ -1253,7 +1253,9 @@ public class DxlClient implements AutoCloseable {
 
         try {
             if (ks != null && this.sslSocketFactoryCallback == null) {
-                this.socketFactory = SSLValidationSocketFactory.newInstance(ks, DxlClientConfig.KS_PASS);
+                this.socketFactory = SSLValidationSocketFactory.newInstance(ks, DxlClientConfig.KS_PASS,
+                    config.getProxyAddress(), config.getProxyPort(),
+                    config.getProxyUserName(), config.getProxyPassword());
             }
             //
             // Each thread is a daemon thread.

--- a/src/main/java/com/opendxl/client/DxlClient.java
+++ b/src/main/java/com/opendxl/client/DxlClient.java
@@ -1339,6 +1339,8 @@ public class DxlClient implements AutoCloseable {
             //setting to version 3.1.1 to prevent repeated connect with earlier MQTT version
             connectOps.setMqttVersion(MqttConnectOptions.MQTT_VERSION_3_1_1);
 
+            connectOps.setHttpsHostnameVerificationEnabled(getConfig().isHttpsHostnameVerificationEnabled());
+
             // Set socket factory if applicable
             if (this.sslSocketFactoryCallback != null) {
                 connectOps.setSocketFactory(this.sslSocketFactoryCallback.createFactory(getConfig()));

--- a/src/main/java/com/opendxl/client/DxlClient.java
+++ b/src/main/java/com/opendxl/client/DxlClient.java
@@ -13,6 +13,7 @@ import com.opendxl.client.message.Message;
 import com.opendxl.client.message.Request;
 import com.opendxl.client.message.Response;
 import com.opendxl.client.util.UuidGenerator;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 import org.eclipse.paho.client.mqttv3.IMqttDeliveryToken;
 import org.eclipse.paho.client.mqttv3.MqttCallback;
@@ -24,6 +25,8 @@ import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence;
 
 import javax.net.ssl.SSLSocketFactory;
 import java.io.IOException;
+import java.net.Authenticator;
+import java.net.PasswordAuthentication;
 import java.security.KeyStore;
 import java.util.HashSet;
 import java.util.List;
@@ -1253,9 +1256,7 @@ public class DxlClient implements AutoCloseable {
 
         try {
             if (ks != null && this.sslSocketFactoryCallback == null) {
-                this.socketFactory = SSLValidationSocketFactory.newInstance(ks, DxlClientConfig.KS_PASS,
-                    config.isUseWebSockets(), config.getProxyAddress(), config.getProxyPort(),
-                    config.getProxyUserName(), config.getProxyPassword());
+                this.socketFactory = SSLValidationSocketFactory.newInstance(ks, DxlClientConfig.KS_PASS);
             }
             //
             // Each thread is a daemon thread.
@@ -1343,12 +1344,41 @@ public class DxlClient implements AutoCloseable {
 
             connectOps.setHttpsHostnameVerificationEnabled(getConfig().isHttpsHostnameVerificationEnabled());
 
-            // Set socket factory if applicable
+            // Get socket factory
+            SSLSocketFactory connectOpsSocketFactory;
             if (this.sslSocketFactoryCallback != null) {
-                connectOps.setSocketFactory(this.sslSocketFactoryCallback.createFactory(getConfig()));
+                connectOpsSocketFactory = this.sslSocketFactoryCallback.createFactory(getConfig());
             } else {
-                connectOps.setSocketFactory(socketFactory);
+                connectOpsSocketFactory = socketFactory;
             }
+
+            // Wrap the socket factory in the ProxySocketFactory if there is a proxy host address
+            if (StringUtils.isNotBlank(this.config.getProxyAddress())) {
+                // Create proxy socket factory
+                connectOpsSocketFactory =
+                    new ProxySocketFactory(connectOpsSocketFactory,
+                        this.config.getProxyAddress(), this.config.getProxyPort());
+
+                // Set the default Authenticator if there is a proxy username and password
+                if (StringUtils.isNotBlank(this.config.getProxyUserName())) {
+                    // Basic authentication was disabled in Java 8
+                    // (https://www.oracle.com/technetwork/java/javase/8u111-relnotes-3124969.html)
+                    // This is a workaround to re-enable basic authentication when making a proxy connection.
+                    // The other alternative is to set this as a system property when starting the OpenDXL Java Client:
+                    // -Djdk.http.auth.tunneling.disabledSchemes= ""
+                    System.setProperty("jdk.http.auth.tunneling.disabledSchemes", "");
+                    Authenticator.setDefault(new Authenticator() {
+                        @Override
+                        protected PasswordAuthentication getPasswordAuthentication() {
+                            return new PasswordAuthentication(
+                                getConfig().getProxyUserName(), getConfig().getProxyPassword());
+                        }
+                    });
+                }
+            }
+
+            // Set the socket factory on the connectOps
+            connectOps.setSocketFactory(connectOpsSocketFactory);
 
             for (Map.Entry<String, Broker> entry : brokers.entrySet()) {
                 if (this.interrupt.get()) {
@@ -1556,7 +1586,7 @@ public class DxlClient implements AutoCloseable {
          * @throws Exception If an error occurs
          */
         SSLSocketFactory createFactory(DxlClientConfig config) throws Exception;
-    };
+    }
 
     /**
      * Implements the {@link MqttCallback} interface (used to received callbacks from the MQTT client.

--- a/src/main/java/com/opendxl/client/DxlClientConfig.java
+++ b/src/main/java/com/opendxl/client/DxlClientConfig.java
@@ -224,7 +224,7 @@ public class DxlClientConfig {
             System.getProperty(Constants.SYSPROP_INCOMING_MESSAGE_QUEUE_SIZE, Integer.toString(16384)));
 
     /**
-     *The HTTP proxy address
+     * The HTTP proxy address
      */
     private String proxyAddress;
 
@@ -685,38 +685,84 @@ public class DxlClientConfig {
         this.delayRandom = percent;
     }
 
+    /**
+     * Returns the HTTP proxy address
+     *
+     * @return The HTTP proxy address
+     */
     public String getProxyAddress() {
         return proxyAddress;
     }
 
+    /**
+     * Sets the HTTP proxy address
+     *
+     * @param proxyAddress The HTTP proxy address
+     */
     public void setProxyAddress(String proxyAddress) {
         this.proxyAddress = proxyAddress;
     }
 
+    /**
+     * Returns the HTTP proxy port
+     *
+     * @return The HTTP proxy port
+     */
     public int getProxyPort() {
         return proxyPort;
     }
 
+    /**
+     * Sets the HTTP proxy port
+     *
+     * @param proxyPort The HTTP proxy port
+     */
     public void setProxyPort(int proxyPort) {
         this.proxyPort = proxyPort;
     }
 
+    /**
+     * Returns the HTTP proxy user name
+     *
+     * @return The HTTP proxy user name
+     */
     public String getProxyUserName() {
         return proxyUserName;
     }
 
+    /**
+     * Sets the HTTP proxy user name
+     *
+     * @param proxyUserName The HTTP proxy user name
+     */
     public void setProxyUserName(String proxyUserName) {
         this.proxyUserName = proxyUserName;
     }
 
+    /**
+     * Returns the the HTTP proxy password
+     *
+     * @return The the HTTP proxy password
+     */
     public char[] getProxyPassword() {
         return proxyPassword;
     }
 
+    /**
+     * Sets the the HTTP proxy password
+     *
+     * @param proxyPassword The the HTTP proxy password
+     */
     public void setProxyPassword(char[] proxyPassword) {
         this.proxyPassword = proxyPassword;
     }
 
+    /**
+     * Method to write out the dxlClient.config file from the DXLClientConfig object member variables
+     *
+     * @param configFile The path to the dxlClient.config file
+     * @throws Exception If there is an issue with writing the dxlClient.config file
+     */
     public void write(String configFile) throws Exception {
         final String certsSection = "Certs";
 

--- a/src/main/java/com/opendxl/client/DxlClientConfig.java
+++ b/src/main/java/com/opendxl/client/DxlClientConfig.java
@@ -128,7 +128,7 @@ public class DxlClientConfig {
     /**
      * Whether to use WebSockets or regular MQTT over tcp
      */
-    private boolean useWebsockets = false;
+    private boolean useWebSockets = false;
 
     /**
      * The number of times to retry during connect, default -1 (infinite)
@@ -304,7 +304,7 @@ public class DxlClientConfig {
         this.privateKey = privateKey;
         this.privateKeyOriginal = privateKey;
         this.websocketBrokers = websocketBrokers;
-        this.useWebsockets = false;
+        this.useWebSockets = false;
     }
 
     /**
@@ -373,7 +373,7 @@ public class DxlClientConfig {
      * @return The list of {@link Broker} objects representing brokers on the DXL fabric
      */
     public List<Broker> getInUseBrokerList() {
-        if (useWebsockets) {
+        if (useWebSockets) {
             return websocketBrokers;
         }
 
@@ -438,18 +438,18 @@ public class DxlClientConfig {
      *
      * @return Whether the client should use WebSockets or regular MQTT over tcp when connecting to a {@link Broker}
      */
-    public boolean isUseWebsockets() {
-        return useWebsockets;
+    public boolean isUseWebSockets() {
+        return useWebSockets;
     }
 
     /**
      * Sets whether the client should use WebSockets or regular MQTT over tcp when connecting to a {@link Broker}
      *
-     * @param useWebsockets Whether the client should use WebSockets or regular MQTT over tcp when connecting to
+     * @param useWebSockets Whether the client should use WebSockets or regular MQTT over tcp when connecting to
      * a {@link Broker}
      */
-    public void setUseWebsockets(boolean useWebsockets) {
-        this.useWebsockets = useWebsockets;
+    public void setUseWebSockets(boolean useWebSockets) {
+        this.useWebSockets = useWebSockets;
     }
 
     /**
@@ -722,7 +722,7 @@ public class DxlClientConfig {
 
         final IniParser parser = new IniParser();
         // Add Use WebSockets
-        parser.addValue(GENERAL_INI_SECTION, USE_WEBSOCKETS_INI_KEY_NAME, String.valueOf(this.useWebsockets));
+        parser.addValue(GENERAL_INI_SECTION, USE_WEBSOCKETS_INI_KEY_NAME, String.valueOf(this.useWebSockets));
 
         // Add Broker Cert Chain
         parser.addValue(CERTS_INI_SECTION, BROKER_CERT_INI_CHAIN_KEY_NAME, this.brokerCaBundlePathOriginal);
@@ -1024,16 +1024,16 @@ public class DxlClientConfig {
      *
      * @param configSection A map representing the keys and values of a Brokers or BrokersWebSockets section of a
      * configuration file.
-     * @param useWebsockets Whether to use WebSockets or regular MQTT over tcp when connecting to a broker
+     * @param useWebSockets Whether to use WebSockets or regular MQTT over tcp when connecting to a broker
      * @return A list of {@link Broker} objects representing the Brokers or BrokersWebSockets section of a
      * configuration file.
      * @throws DxlException If an error occurs
      */
     private static List<Broker> getBrokerListFromConfigSection(Map<String, String> configSection,
-                                                               boolean useWebsockets) throws DxlException {
+                                                               boolean useWebSockets) throws DxlException {
         List<Broker> brokers = new ArrayList<>();
         for (Map.Entry<String, String> entry : configSection.entrySet()) {
-            brokers.add(Broker.parse(entry.getValue(), useWebsockets));
+            brokers.add(Broker.parse(entry.getValue(), useWebSockets));
         }
 
         return brokers;
@@ -1045,7 +1045,7 @@ public class DxlClientConfig {
      *
      * <pre>
      * [General]
-     * useWebSocketBrokers=false
+     * UseWebSockets=false
      *
      * [Certs]
      * BrokerCertChain=c:\\certs\\brokercerts.crt
@@ -1064,7 +1064,7 @@ public class DxlClientConfig {
      * Address=proxy.mycompany.com
      * Port=3128
      * User=proxyUser
-     * Passowrd=proxyPassword
+     * Password=proxyPassword
      *
      * </pre>
      * The configuration file can be loaded as follows:
@@ -1120,7 +1120,7 @@ public class DxlClientConfig {
             dxlClientConfig.brokerCaBundlePathOriginal = brokerCaBundleFileOriginal;
             dxlClientConfig.certFileOriginal = certFileOriginal;
             dxlClientConfig.privateKeyOriginal = privateKeyOriginal;
-            dxlClientConfig.useWebsockets = stringToBooleanMap.get(parser.getValue(GENERAL_INI_SECTION,
+            dxlClientConfig.useWebSockets = stringToBooleanMap.get(parser.getValue(GENERAL_INI_SECTION,
                 USE_WEBSOCKETS_INI_KEY_NAME, (!websocketBrokers.isEmpty() && brokers.isEmpty()) ? "true" : "false"));
 
             // Get the proxy information

--- a/src/main/java/com/opendxl/client/DxlClientConfig.java
+++ b/src/main/java/com/opendxl/client/DxlClientConfig.java
@@ -201,6 +201,11 @@ public class DxlClientConfig {
     private boolean infiniteReconnect = true;
 
     /**
+     * Whether SSL host name verification is enabled when connecting to a broker
+     */
+    private boolean httpsHostnameVerificationEnabled = false;
+
+    /**
      * The logger
      */
     private static Logger logger = Logger.getLogger(DxlClientConfig.class);
@@ -555,6 +560,28 @@ public class DxlClientConfig {
      */
     public boolean isInfiniteReconnectRetries() {
         return this.infiniteReconnect;
+    }
+
+    /**
+     * Returns whether the client should do SSL host name verification when connecting to a broker
+     *
+     * @return Whether the client should do SSL host name verification when connecting to a broker
+     */
+    public boolean isHttpsHostnameVerificationEnabled() {
+        return httpsHostnameVerificationEnabled;
+    }
+
+    /**
+     * Sets whether the client should do SSL host name verification when connecting to a broker.
+     * <P>
+     * Defaults to {@code false}
+     * </P>
+     *
+     * @param httpsHostnameVerificationEnabled Whether the client should do SSL host name
+     *                                         verification when connecting to a broker.
+     */
+    public void setHttpsHostnameVerificationEnabled(boolean httpsHostnameVerificationEnabled) {
+        this.httpsHostnameVerificationEnabled = httpsHostnameVerificationEnabled;
     }
 
     /**

--- a/src/main/java/com/opendxl/client/ProxiedSSLSocket.java
+++ b/src/main/java/com/opendxl/client/ProxiedSSLSocket.java
@@ -1,0 +1,546 @@
+package com.opendxl.client;
+
+import javax.net.ssl.HandshakeCompletedListener;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.SocketAddress;
+import java.net.SocketException;
+import java.nio.channels.SocketChannel;
+
+/**
+ * Helper SSL socket class for establishing connections via a proxy.
+ */
+class ProxiedSSLSocket extends SSLSocket {
+
+    /**
+     * The SSL socket factory
+     */
+    private final SSLSocketFactory socketFactory;
+
+    /**
+     * The socket containing proxy info
+     */
+    private final Socket proxySocket;
+
+    /**
+     * The actual socket created by the socketFactory with the proxySocket information
+     */
+    private SSLSocket socket;
+
+    /**
+     * Constructor
+     *
+     * @param socketFactory The SSL socket factory
+     * @param proxySocket The socket containing proxy info
+     */
+    ProxiedSSLSocket(SSLSocketFactory socketFactory, Socket proxySocket) {
+        this.socketFactory = socketFactory;
+        this.proxySocket = proxySocket;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void connect(SocketAddress socketAddress) throws IOException {
+        connect(socketAddress, 0);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void connect(SocketAddress socketAddress, int timeout) throws IOException {
+        proxySocket.connect(socketAddress, timeout);
+        this.socket = (SSLSocket) socketFactory.createSocket(proxySocket,
+            ((InetSocketAddress) socketAddress).getHostName(), ((InetSocketAddress) socketAddress).getPort(), true);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String[] getSupportedCipherSuites() {
+        return this.socket.getSupportedCipherSuites();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String[] getEnabledCipherSuites() {
+        return this.socket.getEnabledCipherSuites();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setEnabledCipherSuites(String[] strings) {
+        this.socket.setEnabledCipherSuites(strings);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String[] getSupportedProtocols() {
+        return this.socket.getSupportedProtocols();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String[] getEnabledProtocols() {
+        return this.socket.getEnabledProtocols();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setEnabledProtocols(String[] strings) {
+        this.socket.setEnabledProtocols(strings);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public SSLSession getSession() {
+        return this.socket.getSession();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public SSLSession getHandshakeSession() {
+        return this.socket.getHandshakeSession();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void addHandshakeCompletedListener(HandshakeCompletedListener handshakeCompletedListener) {
+        this.socket.addHandshakeCompletedListener(handshakeCompletedListener);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void removeHandshakeCompletedListener(HandshakeCompletedListener handshakeCompletedListener) {
+        this.socket.removeHandshakeCompletedListener(handshakeCompletedListener);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void startHandshake() throws IOException {
+        this.socket.startHandshake();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setUseClientMode(boolean b) {
+        this.socket.setUseClientMode(b);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean getUseClientMode() {
+        return this.socket.getUseClientMode();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setNeedClientAuth(boolean b) {
+        this.socket.setNeedClientAuth(b);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean getNeedClientAuth() {
+        return this.socket.getNeedClientAuth();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setWantClientAuth(boolean b) {
+        this.socket.setWantClientAuth(b);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean getWantClientAuth() {
+        return this.socket.getWantClientAuth();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setEnableSessionCreation(boolean b) {
+        this.socket.setEnableSessionCreation(b);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean getEnableSessionCreation() {
+        return this.socket.getEnableSessionCreation();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public SSLParameters getSSLParameters() {
+        return this.socket.getSSLParameters();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setSSLParameters(SSLParameters sslParameters) {
+        this.socket.setSSLParameters(sslParameters);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void bind(SocketAddress socketAddress) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public InetAddress getInetAddress() {
+        return this.socket.getInetAddress();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public InetAddress getLocalAddress() {
+        return this.socket.getLocalAddress();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getPort() {
+        return this.socket.getPort();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getLocalPort() {
+        return this.socket.getLocalPort();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public SocketAddress getRemoteSocketAddress() {
+        return this.socket.getRemoteSocketAddress();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public SocketAddress getLocalSocketAddress() {
+        return this.socket.getLocalSocketAddress();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public SocketChannel getChannel() {
+        return this.socket.getChannel();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public InputStream getInputStream() throws IOException {
+        return this.socket.getInputStream();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public OutputStream getOutputStream() throws IOException {
+        return this.socket.getOutputStream();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setTcpNoDelay(boolean b) throws SocketException {
+        this.socket.setTcpNoDelay(b);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean getTcpNoDelay() throws SocketException {
+        return this.socket.getTcpNoDelay();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setSoLinger(boolean b, int i) throws SocketException {
+        this.socket.setSoLinger(b, i);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getSoLinger() throws SocketException {
+        return this.socket.getSoLinger();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void sendUrgentData(int i) throws IOException {
+        this.socket.sendUrgentData(i);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setOOBInline(boolean b) throws SocketException {
+        this.socket.setOOBInline(b);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean getOOBInline() throws SocketException {
+        return this.socket.getOOBInline();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setSoTimeout(int i) throws SocketException {
+//        this.socket.setSoTimeout(i); // TODO ?
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getSoTimeout() throws SocketException {
+        return this.socket.getSoTimeout();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setSendBufferSize(int i) throws SocketException {
+        this.socket.setSendBufferSize(i);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getSendBufferSize() throws SocketException {
+        return this.socket.getSendBufferSize();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setReceiveBufferSize(int i) throws SocketException {
+        this.socket.setReceiveBufferSize(i);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getReceiveBufferSize() throws SocketException {
+        return this.socket.getReceiveBufferSize();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setKeepAlive(boolean b) throws SocketException {
+        this.socket.setKeepAlive(b);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean getKeepAlive() throws SocketException {
+        return this.socket.getKeepAlive();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setTrafficClass(int i) throws SocketException {
+        this.socket.setTrafficClass(i);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getTrafficClass() throws SocketException {
+        return this.socket.getTrafficClass();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setReuseAddress(boolean b) throws SocketException {
+        this.socket.setReuseAddress(b);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean getReuseAddress() throws SocketException {
+        return this.socket.getReuseAddress();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void close() throws IOException {
+        this.socket.close();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void shutdownInput() throws IOException {
+        this.socket.shutdownInput();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void shutdownOutput() throws IOException {
+        this.socket.shutdownOutput();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String toString() {
+        return this.socket.toString();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isConnected() {
+        return this.socket.isConnected();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isBound() {
+        return this.socket.isBound();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isClosed() {
+        return this.socket.isClosed();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isInputShutdown() {
+        return this.socket.isInputShutdown();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isOutputShutdown() {
+        return this.socket.isOutputShutdown();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setPerformancePreferences(int i, int i1, int i2) {
+        this.socket.setPerformancePreferences(i, i1, i2);
+    }
+}

--- a/src/main/java/com/opendxl/client/ProxySocketFactory.java
+++ b/src/main/java/com/opendxl/client/ProxySocketFactory.java
@@ -48,7 +48,8 @@ class ProxySocketFactory extends SSLSocketFactory {
      * @return The proxy port
      */
     private static Integer resolveProxyPort() {
-        return Integer.valueOf(System.getProperty("http.proxyPort", "3128"));
+        return Integer.valueOf(System.getProperty("https.proxyPort",
+            System.getProperty("http.proxyPort", "3128")));
     }
 
     /**
@@ -57,7 +58,8 @@ class ProxySocketFactory extends SSLSocketFactory {
      * @return The proxy host
      */
     private static String resolveProxyHost() {
-        return System.getProperty("http.proxyHost", "localhost");
+        return System.getProperty("https.proxyHost",
+            System.getProperty("http.proxyHost", "localhost"));
     }
 
     /**

--- a/src/main/java/com/opendxl/client/ProxySocketFactory.java
+++ b/src/main/java/com/opendxl/client/ProxySocketFactory.java
@@ -1,0 +1,140 @@
+package com.opendxl.client;
+
+import javax.net.ssl.SSLSocketFactory;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.net.Socket;
+import java.net.UnknownHostException;
+
+/**
+ * Helper factory class for establishing connections via a proxy.
+ */
+class ProxySocketFactory extends SSLSocketFactory {
+
+    /**
+     * The SSL socket factory delegate
+     */
+    private final SSLSocketFactory delegate;
+
+    /**
+     * The proxy information
+     */
+    private final Proxy proxy;
+
+    /**
+     * Default constructor
+     */
+    ProxySocketFactory() {
+        this((SSLSocketFactory) SSLSocketFactory.getDefault(), resolveProxyHost(), resolveProxyPort());
+    }
+
+    /**
+     * Constructor
+     *
+     * @param delegate The SSL socket factory delegate
+     * @param proxyHost The proxy host
+     * @param proxyPort The proxy port
+     */
+    ProxySocketFactory(SSLSocketFactory delegate, String proxyHost, int proxyPort) {
+        this.delegate = delegate;
+        this.proxy = buildProxy(proxyHost, proxyPort);
+    }
+
+    /**
+     * Method to get the proxy port form a system property
+     *
+     * @return The proxy port
+     */
+    private static Integer resolveProxyPort() {
+        return Integer.valueOf(System.getProperty("http.proxyPort", "3128"));
+    }
+
+    /**
+     * Method to get the proxy host from a system property
+     *
+     * @return The proxy host
+     */
+    private static String resolveProxyHost() {
+        return System.getProperty("http.proxyHost", "localhost");
+    }
+
+    /**
+     * Method to build a proxy object
+     *
+     * @param proxyHost The proxy host
+     * @param proxyPort The proxy port
+     * @return A proxy object based on the input proxy host and proxy port
+     */
+    private Proxy buildProxy(String proxyHost, int proxyPort) {
+        return new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxyHost, proxyPort));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Socket createSocket() throws IOException {
+        return new ProxiedSSLSocket(delegate, new Socket(proxy));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String[] getDefaultCipherSuites() {
+        return delegate.getDefaultCipherSuites();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String[] getSupportedCipherSuites() {
+        return delegate.getSupportedCipherSuites();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Socket createSocket(Socket s, String host, int port, boolean autoClose) throws IOException {
+        return delegate.createSocket(s, host, port, autoClose);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Socket createSocket(String host, int port) throws IOException, UnknownHostException {
+        return delegate.createSocket(host, port);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Socket createSocket(String host, int port, InetAddress localHost, int localPort)
+        throws IOException, UnknownHostException {
+        return delegate.createSocket(host, port, localHost, localPort);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Socket createSocket(InetAddress host, int port) throws IOException {
+        return delegate.createSocket(host, port);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Socket createSocket(InetAddress address, int port, InetAddress localAddress, int localPort)
+        throws IOException {
+        return delegate.createSocket(address, port, localAddress, localPort);
+    }
+
+}

--- a/src/main/java/com/opendxl/client/SSLValidationSocketFactory.java
+++ b/src/main/java/com/opendxl/client/SSLValidationSocketFactory.java
@@ -69,7 +69,7 @@ class SSLValidationSocketFactory {
             new ProxySocketFactory(sslContext.getSocketFactory(), proxyHost, proxyPort);
 
         // Set the default Authenticator if there is a proxy username and password
-        if (StringUtils.isNoneBlank(proxyUserName)) {
+        if (StringUtils.isNotBlank(proxyUserName)) {
             Authenticator.setDefault(new Authenticator() {
                 @Override
                 protected PasswordAuthentication getPasswordAuthentication() {

--- a/src/main/java/com/opendxl/client/SSLValidationSocketFactory.java
+++ b/src/main/java/com/opendxl/client/SSLValidationSocketFactory.java
@@ -4,20 +4,16 @@
 
 package com.opendxl.client;
 
-import org.apache.commons.lang3.StringUtils;
-
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.TrustManagerFactory;
-import java.net.Authenticator;
-import java.net.PasswordAuthentication;
 import java.security.KeyStore;
 import java.security.SecureRandom;
 
 /**
  * Helper class for SSL connections
- * <p>
+ * <P>
  * Performs validation of presented server certificates and client authentication
  * </P>
  */
@@ -40,15 +36,12 @@ class SSLValidationSocketFactory {
      * We always return a new instance to avoid caching which wouldn't accurately represent a separate client
      * connecting to a broker.
      *
-     * @param keyStore         The keystore
+     * @param keyStore The keystore
      * @param keyStorePassword The keystore
      * @return A new instance of an {@link javax.net.ssl.SSLSocketFactory} that validates presented certificates.
      * @throws Exception If an SSL exception occurs
      */
-    public static SSLSocketFactory newInstance(final KeyStore keyStore, final String keyStorePassword,
-                                               final boolean useWebSockets, final String proxyHost,
-                                               final int proxyPort, final String proxyUserName,
-                                               final char[] proxyPassword)
+    public static SSLSocketFactory newInstance(final KeyStore keyStore, final String keyStorePassword)
         throws Exception {
 
         final TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
@@ -59,32 +52,6 @@ class SSLValidationSocketFactory {
 
         final SSLContext sslContext = SSLContext.getInstance("TLSv1.2");
         sslContext.init(kmf.getKeyManagers(), tmf.getTrustManagers(), secureRandom);
-
-        // If there is no proxy return a non proxy socket factory
-        if (!useWebSockets || StringUtils.isBlank(proxyHost)) {
-            return sslContext.getSocketFactory();
-        }
-
-        // Create proxy socket factory
-        ProxySocketFactory proxySocketFactory =
-            new ProxySocketFactory(sslContext.getSocketFactory(), proxyHost, proxyPort);
-
-        // Set the default Authenticator if there is a proxy username and password
-        if (StringUtils.isNotBlank(proxyUserName)) {
-            // Basic authentication was disabled in Java 8
-            // (https://www.oracle.com/technetwork/java/javase/8u111-relnotes-3124969.html)
-            // This is a workaround to re-enable basic authentication when making a proxy connection.
-            // The other alternative is to set this as a system property when starting the OpenDXL Java Client:
-            // -Djdk.http.auth.tunneling.disabledSchemes= ""
-            System.setProperty("jdk.http.auth.tunneling.disabledSchemes", "");
-            Authenticator.setDefault(new Authenticator() {
-                @Override
-                protected PasswordAuthentication getPasswordAuthentication() {
-                    return new PasswordAuthentication(proxyUserName, proxyPassword);
-                }
-            });
-        }
-
-        return proxySocketFactory;
+        return sslContext.getSocketFactory();
     }
 }

--- a/src/main/java/com/opendxl/client/SSLValidationSocketFactory.java
+++ b/src/main/java/com/opendxl/client/SSLValidationSocketFactory.java
@@ -4,25 +4,33 @@
 
 package com.opendxl.client;
 
+import org.apache.commons.lang3.StringUtils;
+
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.TrustManagerFactory;
+import java.net.Authenticator;
+import java.net.PasswordAuthentication;
 import java.security.KeyStore;
 import java.security.SecureRandom;
 
 /**
  * Helper class for SSL connections
- * <P>
+ * <p>
  * Performs validation of presented server certificates and client authentication
  * </P>
  */
 class SSLValidationSocketFactory {
 
-    /** Secure random */
+    /**
+     * Secure random
+     */
     private static SecureRandom secureRandom = new SecureRandom();
 
-    /** Private constructor */
+    /**
+     * Private constructor
+     */
     private SSLValidationSocketFactory() {
         super();
     }
@@ -32,12 +40,14 @@ class SSLValidationSocketFactory {
      * We always return a new instance to avoid caching which wouldn't accurately represent a separate client
      * connecting to a broker.
      *
-     * @param keyStore The keystore
+     * @param keyStore         The keystore
      * @param keyStorePassword The keystore
      * @return A new instance of an {@link javax.net.ssl.SSLSocketFactory} that validates presented certificates.
      * @throws Exception If an SSL exception occurs
      */
-    public static SSLSocketFactory newInstance(final KeyStore keyStore, final String keyStorePassword)
+    public static SSLSocketFactory newInstance(final KeyStore keyStore, final String keyStorePassword,
+                                               String proxyHost, int proxyPort, String proxyUserName,
+                                               char[] proxyPassword)
         throws Exception {
 
         final TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
@@ -48,6 +58,26 @@ class SSLValidationSocketFactory {
 
         final SSLContext sslContext = SSLContext.getInstance("TLSv1.2");
         sslContext.init(kmf.getKeyManagers(), tmf.getTrustManagers(), secureRandom);
-        return sslContext.getSocketFactory();
+
+        // If there is no proxy return a non proxy socket factory
+        if (StringUtils.isBlank(proxyHost)) {
+            return sslContext.getSocketFactory();
+        }
+
+        // Create proxy socket factory
+        ProxySocketFactory proxySocketFactory =
+            new ProxySocketFactory(sslContext.getSocketFactory(), proxyHost, proxyPort);
+
+        // Set the default Authenticator if there is a proxy username and password
+        if (StringUtils.isNoneBlank(proxyUserName)) {
+            Authenticator.setDefault(new Authenticator() {
+                @Override
+                protected PasswordAuthentication getPasswordAuthentication() {
+                    return new PasswordAuthentication(proxyUserName, proxyPassword);
+                }
+            });
+        }
+
+        return proxySocketFactory;
     }
 }

--- a/src/main/java/com/opendxl/client/cli/CommandLineInterface.java
+++ b/src/main/java/com/opendxl/client/cli/CommandLineInterface.java
@@ -125,13 +125,13 @@ import java.net.URISyntaxException;
  * </pre>
  * <p>
  * <b>Note:</b> If the command must route through a proxy to reach the management server then use standard Java system
- * properties to declare the proxy host, port, user name, and password.
+ * properties to declare the https proxy host, port, user name, and password.
  * (<a href="https://docs.oracle.com/javase/8/docs/technotes/guides/net/proxies.html" target="_blank">https://docs.oracle.com/javase/8/docs/technotes/guides/net/proxies.html</a>)
  * An example usage of this command with Java system properties for the proxy settings is the following:
  * </p>
  * <pre>
- *     $&gt; java -Dhttps.proxyHost=proxy.mycompany.com -Dhttps.proxyPort=3128 -Dhttp.proxyHost=proxy.mycompany.com
- *     -Dhttp.proxyPort=3128 -Dhttp.proxyUser=proxyUser -Dhttp.proxyPassword=proxyPassword
+ *     $&gt; java -Dhttps.proxyHost=proxy.mycompany.com -Dhttps.proxyPort=3128
+ *     -Dhttps.proxyUser=proxyUser -Dhttps.proxyPassword=proxyPassword
  *     -jar dxlclient-0.1.0-all.jar provisionconfig config myserver dxlclient1
  * </pre>
  * </td>
@@ -246,13 +246,13 @@ import java.net.URISyntaxException;
  * </pre>
  * <p>
  * <b>Note:</b> If the command must route through a proxy to reach the management server then use standard Java system
- * properties to declare the proxy host, port, user name, and password.
+ * properties to declare the https proxy host, port, user name, and password.
  * (<a href="https://docs.oracle.com/javase/8/docs/technotes/guides/net/proxies.html" target="_blank">https://docs.oracle.com/javase/8/docs/technotes/guides/net/proxies.html</a>)
  * An example usage of this command with Java system properties for the proxy settings is the following:
  * </p>
  * <pre>
- *     $&gt; java -Dhttps.proxyHost=proxy.mycompany.com -Dhttps.proxyPort=3128 -Dhttp.proxyHost=proxy.mycompany.com
- *     -Dhttp.proxyPort=3128 -Dhttp.proxyUser=proxyUser -Dhttp.proxyPassword=proxyPassword
+ *     $&gt; java -Dhttps.proxyHost=proxy.mycompany.com -Dhttps.proxyPort=3128
+ *     -Dhttps.proxyUser=proxyUser -Dhttps.proxyPassword=proxyPassword
  *     -jar dxlclient-0.1.0-all.jar updateconfig config myserver
  * </pre>
  * </td>

--- a/src/main/java/com/opendxl/client/cli/CommandLineInterface.java
+++ b/src/main/java/com/opendxl/client/cli/CommandLineInterface.java
@@ -123,6 +123,17 @@ import java.net.URISyntaxException;
  * <pre>
  *     $&gt; java -jar dxlclient-0.1.0-all.jar provisionconfig config myserver dxlclient1
  * </pre>
+ * <p>
+ * <b>Note:</b> If the command must route through a proxy to reach the management server then use standard Java system
+ * properties to declare the proxy host, port, user name, and password.
+ * (<a href="https://docs.oracle.com/javase/8/docs/technotes/guides/net/proxies.html" target="_blank">https://docs.oracle.com/javase/8/docs/technotes/guides/net/proxies.html</a>)
+ * An example usage of this command with Java system properties for the proxy settings is the following:
+ * </p>
+ * <pre>
+ *     $&gt; java -Dhttps.proxyHost=proxy.mycompany.com -Dhttps.proxyPort=3128 -Dhttp.proxyHost=proxy.mycompany.com
+ *     -Dhttp.proxyPort=3128 -Dhttp.proxyUser=proxyUser -Dhttp.proxyPassword=proxyPassword
+ *     -jar dxlclient-0.1.0-all.jar provisionconfig config myserver dxlclient1
+ * </pre>
  * </td>
  * </tr>
  * <tr>
@@ -232,6 +243,17 @@ import java.net.URISyntaxException;
  * </p>
  * <pre>
  *     $&gt; java -jar dxlclient-0.1.0-all.jar updateconfig config myserver
+ * </pre>
+ * <p>
+ * <b>Note:</b> If the command must route through a proxy to reach the management server then use standard Java system
+ * properties to declare the proxy host, port, user name, and password.
+ * (<a href="https://docs.oracle.com/javase/8/docs/technotes/guides/net/proxies.html" target="_blank">https://docs.oracle.com/javase/8/docs/technotes/guides/net/proxies.html</a>)
+ * An example usage of this command with Java system properties for the proxy settings is the following:
+ * </p>
+ * <pre>
+ *     $&gt; java -Dhttps.proxyHost=proxy.mycompany.com -Dhttps.proxyPort=3128 -Dhttp.proxyHost=proxy.mycompany.com
+ *     -Dhttp.proxyPort=3128 -Dhttp.proxyUser=proxyUser -Dhttp.proxyPassword=proxyPassword
+ *     -jar dxlclient-0.1.0-all.jar updateconfig config myserver
  * </pre>
  * </td>
  * </tr>

--- a/src/main/java/com/opendxl/client/cli/ManagementService.java
+++ b/src/main/java/com/opendxl/client/cli/ManagementService.java
@@ -219,6 +219,7 @@ class ManagementService {
         }
 
         return HttpClients.custom()
+                .useSystemProperties()
                 .setDefaultRequestConfig(createRequestConfig())
                 .setConnectionManager(createConnectionManager(socketFactory))
                 .setDefaultCookieStore(new BasicCookieStore())

--- a/src/main/java/com/opendxl/client/cli/ManagementService.java
+++ b/src/main/java/com/opendxl/client/cli/ManagementService.java
@@ -7,7 +7,11 @@ package com.opendxl.client.cli;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpHeaders;
+import org.apache.http.HttpHost;
 import org.apache.http.NameValuePair;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
 import org.apache.http.client.config.CookieSpecs;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -16,15 +20,18 @@ import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.config.Registry;
 import org.apache.http.config.RegistryBuilder;
 import org.apache.http.conn.HttpClientConnectionManager;
+import org.apache.http.conn.routing.HttpRoutePlanner;
 import org.apache.http.conn.socket.ConnectionSocketFactory;
 import org.apache.http.conn.socket.PlainConnectionSocketFactory;
 import org.apache.http.conn.ssl.DefaultHostnameVerifier;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.impl.client.BasicCookieStore;
+import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.BasicResponseHandler;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.impl.client.LaxRedirectStrategy;
+import org.apache.http.impl.conn.DefaultProxyRoutePlanner;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.apache.http.ssl.SSLContexts;
 
@@ -219,12 +226,55 @@ class ManagementService {
         }
 
         return HttpClients.custom()
-                .useSystemProperties()
-                .setDefaultRequestConfig(createRequestConfig())
-                .setConnectionManager(createConnectionManager(socketFactory))
-                .setDefaultCookieStore(new BasicCookieStore())
-                .setRedirectStrategy(new LaxRedirectStrategy())
-                .build();
+            .setDefaultRequestConfig(createRequestConfig())
+            .setConnectionManager(createConnectionManager(socketFactory))
+            .setDefaultCookieStore(new BasicCookieStore())
+            .setRedirectStrategy(new LaxRedirectStrategy())
+            .setRoutePlanner(createRoutePlanner())
+            .setDefaultCredentialsProvider(createCredentialsProvider())
+            .build();
+    }
+
+    /**
+     * Creates and returns a {@link HttpRoutePlanner} based on the standard Java system properties for https proxy
+     * information
+     *
+     * @return A {@link HttpRoutePlanner} based on the standard Java system properties for https proxy
+     * information
+     */
+    private HttpRoutePlanner createRoutePlanner() {
+        DefaultProxyRoutePlanner routePlanner = null;
+        String httpsProxyHost = System.getProperty("https.proxyHost", "");
+        int httpsProxyPort = Integer.parseInt(System.getProperty("https.proxyPort", "0"));
+        if (StringUtils.isNotBlank(httpsProxyHost)) {
+            HttpHost proxy = new HttpHost(httpsProxyHost, httpsProxyPort);
+            routePlanner = new DefaultProxyRoutePlanner(proxy);
+        }
+        return routePlanner;
+    }
+
+    /**
+     * Creates and returns a {@link CredentialsProvider} based on the specified descriptor properties
+     *
+     * @return A {@link CredentialsProvider} based on the specified descriptor properties
+     */
+    private CredentialsProvider createCredentialsProvider() {
+        CredentialsProvider credsProvider = new BasicCredentialsProvider();
+
+        String httpsProxyHost = System.getProperty("https.proxyHost", "");
+        int httpsProxyPort = Integer.parseInt(System.getProperty("https.proxyPort", "0"));
+        String httpsProxyUser = System.getProperty("https.proxyUser", "");
+        String httpsProxyPassword = System.getProperty("https.proxyPassword", "");
+
+        if (StringUtils.isNotBlank(httpsProxyHost)) {
+            // if an HTTP proxy username has been provided add credentials for the HTTP proxy
+            if (StringUtils.isNotBlank(httpsProxyUser)) {
+                credsProvider.setCredentials(
+                    new AuthScope(httpsProxyHost, httpsProxyPort),
+                    new UsernamePasswordCredentials(httpsProxyUser, httpsProxyPassword));
+            }
+        }
+        return credsProvider;
     }
 
     /**

--- a/src/test/java/com/opendxl/client/ProxyUsageVerificationTest.java
+++ b/src/test/java/com/opendxl/client/ProxyUsageVerificationTest.java
@@ -23,7 +23,7 @@ public class ProxyUsageVerificationTest {
             client.connect();
         } catch (Exception e) {
             e.printStackTrace();
-            assertTrue(e.getMessage().contains("Unable to connect to server: Connection refused: connect"));
+            assertTrue(e.getMessage().contains("Unable to connect to server: Connection refused"));
         }
 
         config.setProxyPort(originalProxyPort);

--- a/src/test/java/com/opendxl/client/ProxyUsageVerificationTest.java
+++ b/src/test/java/com/opendxl/client/ProxyUsageVerificationTest.java
@@ -1,0 +1,36 @@
+package com.opendxl.client;
+
+import com.opendxl.client.exception.DxlException;
+import com.opendxl.client.testutil.impl.DxlClientImplFactory;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class ProxyUsageVerificationTest {
+
+    @Test
+    public void verifyProxyUsage() throws DxlException {
+
+        DxlClientImplFactory dxlClientImplFactory = DxlClientImplFactory.getDefaultInstance();
+        DxlClientConfig config = dxlClientImplFactory.getConfig();
+
+        int originalProxyPort = config.getProxyPort();
+
+        config.setProxyPort(originalProxyPort - 10);
+        try (DxlClient client = new DxlClient(config)) {
+            client.getConfig().setConnectRetries(1);
+            client.connect();
+        } catch (Exception e) {
+            assertTrue(e.getMessage().contains("Unable to connect to server: Connection refused: connect"));
+        }
+
+        config.setProxyPort(originalProxyPort);
+        try (DxlClient client = new DxlClient(config)) {
+            client.getConfig().setConnectRetries(1);
+            client.connect();
+        } catch (Exception e) {
+            fail();
+        }
+    }
+}

--- a/src/test/java/com/opendxl/client/ProxyUsageVerificationTest.java
+++ b/src/test/java/com/opendxl/client/ProxyUsageVerificationTest.java
@@ -7,8 +7,16 @@ import org.junit.Test;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+/**
+ * Test class for verifying WebSocket connection to a broker via a proxy
+ */
 public class ProxyUsageVerificationTest {
 
+    /**
+     * Test to verifying WebSocket connection to a broker via a proxy
+     *
+     * @throws DxlException If there is an issue getting the DXL Client config
+     */
     @Test
     public void verifyProxyUsage() throws DxlException {
 
@@ -16,8 +24,10 @@ public class ProxyUsageVerificationTest {
         DxlClientConfig config = dxlClientImplFactory.getConfig();
 
         int originalProxyPort = config.getProxyPort();
-
+        // Modify the proxy port to be something other than the proxy port
         config.setProxyPort(originalProxyPort - 10);
+
+        // Attempt to connect with the invalid proxy information and expect a connection refused failure
         try (DxlClient client = new DxlClient(config)) {
             client.getConfig().setConnectRetries(1);
             client.connect();
@@ -26,6 +36,7 @@ public class ProxyUsageVerificationTest {
             assertTrue(e.getMessage().contains("Unable to connect to server: Connection refused"));
         }
 
+        // Attempt to connect with the valid proxy information and do not expect an exception
         config.setProxyPort(originalProxyPort);
         try (DxlClient client = new DxlClient(config)) {
             client.getConfig().setConnectRetries(1);

--- a/src/test/java/com/opendxl/client/ProxyUsageVerificationTest.java
+++ b/src/test/java/com/opendxl/client/ProxyUsageVerificationTest.java
@@ -22,6 +22,7 @@ public class ProxyUsageVerificationTest {
             client.getConfig().setConnectRetries(1);
             client.connect();
         } catch (Exception e) {
+            e.printStackTrace();
             assertTrue(e.getMessage().contains("Unable to connect to server: Connection refused: connect"));
         }
 

--- a/testing/squid.conf
+++ b/testing/squid.conf
@@ -5,7 +5,9 @@
 # Example rule allowing access from your local networks.
 # Adapt to list your (internal) IP networks from where browsing
 # should be allowed
-auth_param basic program /usr/lib64/squid/basic_ncsa_auth /etc/squid/passwords
+# Use /usr/lib/squid/basic_ncsa_auth instead of /usr/lib64/squid/basic_ncsa_auth because
+# the sameersbn/squid docker container creates /usr/lib/squid/basic_ncsa_auth
+auth_param basic program /usr/lib/squid/basic_ncsa_auth /etc/squid/passwords
 auth_param basic children 5
 auth_param basic realm Squid Basic Authentication
 auth_param basic credentialsttl 2 hours

--- a/testing/squid.conf
+++ b/testing/squid.conf
@@ -5,12 +5,12 @@
 # Example rule allowing access from your local networks.
 # Adapt to list your (internal) IP networks from where browsing
 # should be allowed
-#auth_param basic program /usr/lib64/squid/basic_ncsa_auth /etc/squid/passwd
-#auth_param basic children 5
-#auth_param basic realm Squid Basic Authentication
-#auth_param basic credentialsttl 2 hours
-#acl auth_users proxy_auth REQUIRED
-#http_access allow auth_users
+auth_param basic program /usr/lib64/squid/basic_ncsa_auth /etc/squid/passwords
+auth_param basic children 5
+auth_param basic realm Squid Basic Authentication
+auth_param basic credentialsttl 2 hours
+acl auth_users proxy_auth REQUIRED
+http_access allow auth_users
 
 acl localnet src 0.0.0.0/0
 acl localnet src 10.0.0.0/8	# RFC1918 possible internal network
@@ -18,8 +18,8 @@ acl localnet src 172.16.0.0/12	# RFC1918 possible internal network
 acl localnet src 192.168.0.0/16	# RFC1918 possible internal network
 acl localnet src fc00::/7       # RFC 4193 local private network range
 acl localnet src fe80::/10      # RFC 4291 link-local (directly plugged) machines
-acl all src 0.0.0.0/0
-http_access allow all
+#acl all src 0.0.0.0/0
+#http_access allow all
 
 acl SSL_ports port 443
 acl Safe_ports port 80		# http

--- a/testing/squid.conf
+++ b/testing/squid.conf
@@ -1,0 +1,94 @@
+#
+# Recommended minimum configuration:
+#
+
+# Example rule allowing access from your local networks.
+# Adapt to list your (internal) IP networks from where browsing
+# should be allowed
+#auth_param basic program /usr/lib64/squid/basic_ncsa_auth /etc/squid/passwd
+#auth_param basic children 5
+#auth_param basic realm Squid Basic Authentication
+#auth_param basic credentialsttl 2 hours
+#acl auth_users proxy_auth REQUIRED
+#http_access allow auth_users
+
+acl localnet src 0.0.0.0/0
+acl localnet src 10.0.0.0/8	# RFC1918 possible internal network
+acl localnet src 172.16.0.0/12	# RFC1918 possible internal network
+acl localnet src 192.168.0.0/16	# RFC1918 possible internal network
+acl localnet src fc00::/7       # RFC 4193 local private network range
+acl localnet src fe80::/10      # RFC 4291 link-local (directly plugged) machines
+acl all src 0.0.0.0/0
+http_access allow all
+
+acl SSL_ports port 443
+acl Safe_ports port 80		# http
+acl Safe_ports port 21		# ftp
+acl Safe_ports port 443		# https
+acl Safe_ports port 70		# gopher
+acl Safe_ports port 210		# wais
+acl Safe_ports port 1025-65535	# unregistered ports
+acl Safe_ports port 280		# http-mgmt
+acl Safe_ports port 488		# gss-http
+acl Safe_ports port 591		# filemaker
+acl Safe_ports port 777		# multiling http
+acl CONNECT method CONNECT
+
+# custom settings
+#dns_v4_first off
+#ssl_bump peek all
+pinger_enable off
+half_closed_clients off
+quick_abort_min 0 KB
+quick_abort_max 0 KB
+quick_abort_pct 95
+client_persistent_connections off
+server_persistent_connections off
+
+#
+# Recommended minimum Access Permission configuration:
+#
+# Deny requests to certain unsafe ports
+#http_access deny !Safe_ports
+
+# Deny CONNECT to other than secure SSL ports
+#http_access deny CONNECT !SSL_ports
+
+# Only allow cachemgr access from localhost
+http_access allow localhost manager
+http_access deny manager
+
+# We strongly recommend the following be uncommented to protect innocent
+# web applications running on the proxy server who think the only
+# one who can access services on "localhost" is a local user
+#http_access deny to_localhost
+
+#
+# INSERT YOUR OWN RULE(S) HERE TO ALLOW ACCESS FROM YOUR CLIENTS
+#
+
+# Example rule allowing access from your local networks.
+# Adapt localnet in the ACL section to list your (internal) IP networks
+# from where browsing should be allowed
+http_access allow localnet
+http_access allow localhost
+
+# And finally deny all other access to this proxy
+#http_access allow all
+
+# Squid normally listens to port 3128
+http_port 3128
+
+# Uncomment and adjust the following to add a disk cache directory.
+#cache_dir ufs /var/spool/squid 100 16 256
+
+# Leave coredumps in the first cache dir
+coredump_dir /var/spool/squid
+
+#
+# Add any of your own refresh_pattern entries above these.
+#
+refresh_pattern ^ftp:		1440	20%	10080
+refresh_pattern ^gopher:	1440	0%	1440
+refresh_pattern -i (/cgi-bin/|\?) 0	0%	0
+refresh_pattern .		0	20%	4320


### PR DESCRIPTION
The ability to use a proxy with WebSocket connections is primarily based on discussion here: https://github.com/eclipse/paho.mqtt.java/issues/573#issuecomment-484773525. The paho.mqtt.java 1.2.1 comes from the following opendxl-community fork of paho.mqtt.java: https://github.com/opendxl-community/paho.mqtt.java/tree/opendxl-modifications-merge-1.2.1.