### PR TITLE
Revert "log4j upgrade to 2.17.0"

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,12 @@ Maven:
 <dependency>
   <groupId>com.opendxl</groupId>
   <artifactId>dxlclient</artifactId>
-  <version>0.2.7</version>
+  <version>0.2.6</version>
 </dependency>
 ```
 or Gradle:
 ```groovy
-compile 'com.opendxl:dxlclient:0.2.7'
+compile 'com.opendxl:dxlclient:0.2.6'
 ```
 
 ## Bugs and Feedback

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-annotations:2.9.7'
     implementation 'com.fasterxml.jackson.core:jackson-core:2.9.7'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.9.7'
-    implementation 'log4j:log4j:2.17.0'
+    implementation 'log4j:log4j:1.2.17'
 //    implementation 'org.apache.logging.log4j:log4j-api:2.11.1'
 //    implementation 'org.apache.logging.log4j:log4j-core:2.11.1'
     implementation 'org.msgpack:msgpack:0.6.7'

--- a/docs/prerequisites.rst
+++ b/docs/prerequisites.rst
@@ -53,10 +53,10 @@ Maven:
         <dependency>
           <groupId>com.opendxl</groupId>
           <artifactId>dxlclient</artifactId>
-          <version>0.2.7</version>
+          <version>0.2.6</version>
         </dependency>
 or Gradle:
 
     .. code-block:: groovy
 
-        compile 'com.opendxl:dxlclient:0.2.7'
+        compile 'com.opendxl:dxlclient:0.2.6'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.2.7
+version=0.2.7-SNAPSHOT


### PR DESCRIPTION
This reverts commit 4409191

This is not correct "implementation 'log4j:log4j:1.2.17'" and cause compilation issue. 
Also change from log4J-1.x to 2.x needs additional changes or use of bridge. 