### PR TITLE
Release 0.2.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,12 @@ Maven:
 <dependency>
   <groupId>com.opendxl</groupId>
   <artifactId>dxlclient</artifactId>
-  <version>0.2.6</version>
+  <version>0.2.9</version>
 </dependency>
 ```
 or Gradle:
 ```groovy
-compile 'com.opendxl:dxlclient:0.2.6'
+compile 'com.opendxl:dxlclient:0.2.9'
 ```
 
 ## Bugs and Feedback

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.2.8
+version=0.2.9


### PR DESCRIPTION
For ipv6 support, changes are made to skip SNI object creation from ipv6 address
For ipv6 DXL broker, SNI object creation was failing due to colon character in ipv6

Paho eclipse master is not used for opendxl-client-java  0.2.8.       
release-0.2.8 uses **opendxl-modifications-merge-1.2.1** branch so i created a branch from opendxl-modifications-merge-1.2.1

Will document the whole process to change paho eclipse client java in trellix confluence.